### PR TITLE
Make 'json_' prefix configurable.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>dk.jyskebank.tooling.enunciate</groupId>
     <artifactId>enunciate-openapi</artifactId>
     <name>Enunciate module for OpenAPI</name>
-    <version>1.0.5-SNAPSHOT</version>
+    <version>1.0.9-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/DataTypeReferenceRenderer.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/DataTypeReferenceRenderer.java
@@ -31,9 +31,11 @@ import dk.jyskebank.tools.enunciate.modules.openapi.yaml.YamlHelper;
 
 public class DataTypeReferenceRenderer {
 	private final EnunciateLogger logger;
-  
-	public DataTypeReferenceRenderer(EnunciateLogger logger) {
+	private boolean removeObjectPrefix;
+
+	public DataTypeReferenceRenderer(EnunciateLogger logger, boolean removeObjectPrefix) {
 		this.logger = logger;
+		this.removeObjectPrefix = removeObjectPrefix;
 	}
   
   	public void render(IndententationPrinter ip, DataTypeReference dtr, String description) {
@@ -88,6 +90,10 @@ public class DataTypeReferenceRenderer {
 	    	}
 	    }
   	}
+
+	public boolean doRemoveObjectPrefix() {
+		return removeObjectPrefix;
+	}
 
   private void renderContainer(IndententationPrinter ip, boolean isMap, Runnable valueTypeRendere) {
       if (isMap) {

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/ObjectTypeRenderer.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/ObjectTypeRenderer.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -53,372 +53,378 @@ import dk.jyskebank.tools.enunciate.modules.openapi.yaml.IndententationPrinter;
 import dk.jyskebank.tools.enunciate.modules.openapi.yaml.JsonToYamlHelper;
 
 public class ObjectTypeRenderer {
-  private final EnunciateLogger logger;
-  private final DataTypeReferenceRenderer datatypeRefRenderer;
-  private final Set<String> passThroughAnnotations;
+    private final EnunciateLogger logger;
+    private final DataTypeReferenceRenderer datatypeRefRenderer;
+    private final Set<String> passThroughAnnotations;
 
-  public ObjectTypeRenderer(EnunciateLogger enunciateLogger, DataTypeReferenceRenderer datatypeRefRenderer, Set<String> passThroughAnnotations) {
-    this.logger = enunciateLogger;
-    this.datatypeRefRenderer = datatypeRefRenderer;
-    this.passThroughAnnotations = passThroughAnnotations;
-  }
-  
-  public void render(IndententationPrinter ip, DataType datatype, boolean syntaxIsJson) {
-    logger.info("Rendering type " + datatype.getLabel());
-    ip.pushNextLevel();
-    ip.add("title: ", safeYamlString(datatype.getLabel()));
-    addOptionalSupertypeHeader(ip, datatype);
+    private final boolean removeObjectPrefix;
 
-    ip.add("type: ", getBaseType(datatype));
-    addOptionalRequired(ip, datatype);
-    addOptionalProperties(ip, datatype, syntaxIsJson);
-    addOptionalEnum(ip, datatype);
-    addOptionalXml(ip, datatype);
-    
-    addOptionalExample(ip, datatype, syntaxIsJson);
-    
-    ip.popLevel();
-  }
-
-  private void addOptionalSupertypeHeader(IndententationPrinter ip, DataType datatype) {
-    List<DataTypeReference> supertypes = datatype.getSupertypes();
-    if (supertypes == null || supertypes.isEmpty()) {
-      return;
-    }
-    
-    ip.add("allOf:");
-    ip.nextLevel();
-    ip.itemFollows();
-
-    DataTypeReference superType = supertypes.iterator().next();
-    datatypeRefRenderer.addSchemaRef(ip, superType);
-
-    ip.itemFollows();
-  }
-
-  private void addOptionalRequired(IndententationPrinter ip, DataType datatype) {
-    List<? extends Property> properties = datatype.getProperties();
-    if (properties == null) {
-      return;
-    }
-    
-    List<Property> requiredProperties = new ArrayList<>();
-    for (Property p : properties) {
-      if (p.isRequired()) {
-        requiredProperties.add(p);
-      }
-    }
-    
-    if (requiredProperties.isEmpty()) {
-      return;
-    }
-    
-    ip.add("required:");
-    ip.nextLevel();
-    for (Property p : requiredProperties) {
-      ip.item(p.getName());
-    }
-    ip.prevLevel();
-  }
-
-  private static String getBaseType(DataType datatype) {
-    switch (datatype.getBaseType()) {
-    case bool:
-      return "boolean";
-    case number:
-      return "number";
-    case string:
-      return "string";
-    default:
-      return "object";
-    }
-  }
-  
-  private void addOptionalEnum(IndententationPrinter ip, DataType datatype) {
-    List<? extends Value> values = datatype.getValues();
-    if (values == null || values.isEmpty()) {
-      return;
-    }
-    
-    List<String> enums = values.stream()
-      .map(Value::getValue)
-      .collect(toList());
-    renderEnum(ip, enums);
-  }
-
-  public void renderEnum(IndententationPrinter ip, List<String> values) {
-    ip.add("enum:");
-    ip.nextLevel();
-    for (String e : values) {
-      ip.item(e);
-    }
-    ip.prevLevel();
-  }
-
-  private void addOptionalProperties(IndententationPrinter ip, DataType datatype, boolean syntaxIsJson) {
-    List<? extends Property> properties = datatype.getProperties();
-    if (properties == null || properties.isEmpty()) {
-      return;
-    }
-    
-    ip.add("properties:");
-    ip.nextLevel();
-    for (Property p : properties) {
-      addProperty(ip, datatype, p, syntaxIsJson);
-    }
-    ip.prevLevel();
-  }
-
-  private void addProperty(IndententationPrinter ip, DataType datatype, Property p, boolean syntaxIsJson) {
-    logger.info(" adding property " + p.getName() + " with annotations " + p.getAnnotations().keySet());
-    
-    ip.add(p.getName(), ":");
-    ip.nextLevel();
-    if (datatype.getPropertyMetadata().containsKey("namespaceInfo")) {
-      addNamespaceXml(ip, p);
-    }
-    
-	addOptionalNullable(ip, p);
-    
-    addConstraints(ip, p);
-    if (p.isReadOnly()) {
-      ip.add("readOnly: ", Boolean.toString(p.isReadOnly()));
-    }
-    
-    datatypeRefRenderer.render(ip, p.getDataType(), p.getDescription());
-    
-    addOptionalPropertyExample(ip, p, syntaxIsJson);
-    addPassThroughAnnotations(ip, p);
-    
-    ip.prevLevel();
-  }
-
-  private void addPassThroughAnnotations(IndententationPrinter ip, Property p) {
-    List<String> annotations = p.getAnnotations().entrySet().stream()
-      .filter(e -> passThroughAnnotations.contains(e.getKey()))
-      .map(e -> renderAnnotation(e.getKey(), e.getValue().getElementValues()))
-      .peek(s -> logger.info("  with " + s))
-      .collect(toList());
-    
-    if (!annotations.isEmpty()) {
-      ip.add("x-annotations:");
-      ip.nextLevel();
-      annotations.forEach(a -> ip.add("- '", a, "'"));
-      ip.prevLevel();
-    }
-  }
-  
-  private String renderAnnotation(String annotationName, Map<? extends ExecutableElement, ? extends AnnotationValue> annotationOptions) {
-    StringBuilder sb = new StringBuilder("@")
-        .append(annotationName);
-    if (!annotationOptions.isEmpty()) {
-      String args = annotationOptions.entrySet().stream()
-        .map(e -> {
-          String n = e.getKey().toString().replace("()", "");
-          String v = e.getValue().toString();
-          return n + "=" + v;
-        })
-        .collect(joining(", "));
-      
-      sb.append("(").append(args).append(")");
-    }
-    return sb.toString();
-  }
-
-  private static void addConstraints(IndententationPrinter ip, Property p) {
-    List<ContainerType> containers = p.getDataType().getContainers();
-    boolean isArray = containers != null && !containers.isEmpty();
-    
-    Max max = p.getAnnotation(Max.class);
-    DecimalMax decimalMax = p.getAnnotation(DecimalMax.class);
-    if (max != null) {
-      ip.add("maximum: ", Long.toString(max.value()));
-    } else if (decimalMax != null) {
-      ip.add("maximum: ", decimalMax.value());
-      ip.add("exclusiveMaximum: ", Boolean.toString(!decimalMax.inclusive()));
+    public ObjectTypeRenderer(EnunciateLogger enunciateLogger, DataTypeReferenceRenderer datatypeRefRenderer, Set<String> passThroughAnnotations, boolean removeObjectPrefix) {
+        this.logger = enunciateLogger;
+        this.datatypeRefRenderer = datatypeRefRenderer;
+        this.passThroughAnnotations = passThroughAnnotations;
+        this.removeObjectPrefix = removeObjectPrefix;
     }
 
-    Min min = p.getAnnotation(Min.class);
-    DecimalMin decimalMin = p.getAnnotation(DecimalMin.class);
-    if (min != null) {
-      ip.add("minimum: ", Long.toString(min.value()));
-    } else if (decimalMin != null) {
-      ip.add("minimum: ", decimalMin.value());
-      ip.add("exclusiveMinimum: ", Boolean.toString(!decimalMin.inclusive()));
+    public void render(IndententationPrinter ip, DataType datatype, boolean syntaxIsJson) {
+        logger.info("Rendering type " + datatype.getLabel());
+        ip.pushNextLevel();
+        ip.add("title: ", safeYamlString(datatype.getLabel()));
+        addOptionalSupertypeHeader(ip, datatype);
+
+        ip.add("type: ", getBaseType(datatype));
+        addOptionalRequired(ip, datatype);
+        addOptionalProperties(ip, datatype, syntaxIsJson);
+        addOptionalEnum(ip, datatype);
+        addOptionalXml(ip, datatype);
+
+        addOptionalExample(ip, datatype, syntaxIsJson);
+
+        ip.popLevel();
     }
 
-    Size size = p.getAnnotation(Size.class);
-    if (size != null) {
-      if (isArray) {
-        ip.add("maxItems: ", Integer.toString(size.max()));
-        ip.add("minItems: ", Integer.toString(size.min()));
-      }
-      else {
-        ip.add("maxLength: ", Integer.toString(size.max()));
-        ip.add("minLength: ", Integer.toString(size.min()));
-      }
+    private void addOptionalSupertypeHeader(IndententationPrinter ip, DataType datatype) {
+        List<DataTypeReference> supertypes = datatype.getSupertypes();
+        if (supertypes == null || supertypes.isEmpty()) {
+            return;
+        }
+
+        ip.add("allOf:");
+        ip.nextLevel();
+        ip.itemFollows();
+
+        DataTypeReference superType = supertypes.iterator().next();
+        datatypeRefRenderer.addSchemaRef(ip, superType);
+
+        ip.itemFollows();
     }
 
-    Pattern mustMatchPattern = p.getAnnotation(Pattern.class);
-    if (mustMatchPattern != null) {
-      ip.add("pattern: ", mustMatchPattern.regexp());
-    }
-  }
+    private void addOptionalRequired(IndententationPrinter ip, DataType datatype) {
+        List<? extends Property> properties = datatype.getProperties();
+        if (properties == null) {
+            return;
+        }
 
-  	private void addOptionalNullable(IndententationPrinter ip, Property p) {
-  		getNillable(p).ifPresent(isNullable -> {
-	  		if (!TypeHelper.renderAsSimpleRef(p.getDataType())) {
-	  			ip.add("nullable: ", isNullable);
-	  		}
-  		});
-  	}
+        List<Property> requiredProperties = new ArrayList<>();
+        for (Property p : properties) {
+            if (p.isRequired()) {
+                requiredProperties.add(p);
+            }
+        }
 
-  private void addNamespaceXml(IndententationPrinter ip, Property p) {
-    PropertyMetadata metadata = AccessorProperty.getMetadata(p);
-    if (metadata == null) {
-      return;
-    }
+        if (requiredProperties.isEmpty()) {
+            return;
+        }
 
-    Optional<String> wrappedName = getWrappedName(p);
-    String namespace = metadata.getTitle();
-
-    boolean renderAttribute = AccessorProperty.isAttribute(p);
-    boolean renderNamespace = namespace != null && !namespace.isEmpty();
-    
-    if (!wrappedName.isPresent() && !renderAttribute && !renderNamespace) {
-      return;
-    }
-    
-    ip.add("xml:");
-    ip.nextLevel();
-    wrappedName.ifPresent(name -> {
-      ip.add("name: ", name);
-      ip.add("wrapped: true");
-    });
-    if (renderAttribute) {
-      ip.add("attribute: ", Boolean.TRUE.toString());
-    }
-    if (renderNamespace) {
-      ip.add("namespace: ", namespace);
-    }
-    ip.prevLevel();
-  }
-
-  private Optional<String> getWrappedName(Property p) {
-    return getAttributeValue(p, "javax.xml.bind.annotation.XmlElementWrapper", "name()");
-  }
-
-  private Optional<String> getNillable(Property p) {
-    return getAttributeValue(p, "javax.xml.bind.annotation.XmlElement", "nillable()");
-  }
-
-  private Optional<String> getAttributeValue(Property p, String annotationName, String propertyName) {
-    return p.getAnnotations().entrySet().stream()
-      .filter(e -> annotationName.equals(e.getKey()))
-      .flatMap(am -> am.getValue().getElementValues().entrySet().stream())
-      .filter(e -> propertyName.equals(e.getKey().toString()))
-      .map(e -> e.getValue().getValue())
-      .filter(Objects::nonNull)
-      .map(Objects::toString)
-      .findFirst();
-  }
-
-  private void addOptionalXml(IndententationPrinter ip, DataType datatype) {
-    String xmlName = getNonNullAndNonEmpty(AccessorDataType.getXmlName(datatype));
-    
-    Namespace namespace = datatype.getNamespace();
-    String xmlNamespace = getNonNullAndNonEmpty(namespace != null ? namespace.getUri() : null); 
-    
-    logger.debug("optionalXml for " + datatype.getLabel() + " : " + xmlName + " / " + xmlNamespace);
-    
-    if (xmlName != null || xmlNamespace != null) {
-      ip.add("xml:");
-      ip.nextLevel();
-      if (xmlName != null) {
-        ip.add("name: ", xmlName);
-      }
-      if (xmlNamespace != null) {
-        ip.add("namespace: ", xmlNamespace);
-      }
-      ip.prevLevel();
-    }
-  }
-  
-  private static String getNonNullAndNonEmpty(String str) {
-    if (str == null) {
-      return null;
-    }
-    return str.isEmpty() ? null : str;
-  }
-  
-  private static void addOptionalExample(IndententationPrinter ip, DataType datatype, boolean syntaxIsJson) {
-    if (!syntaxIsJson) {
-      return;
+        ip.add("required:");
+        ip.nextLevel();
+        for (Property p : requiredProperties) {
+            ip.item(p.getName());
+        }
+        ip.prevLevel();
     }
 
-    renderExample(ip, getExampleFromType(datatype, datatype.getBaseType(), Optional.empty()));
-  }
-
-  private static void addOptionalPropertyExample(IndententationPrinter ip, Property property, boolean syntaxIsJson) {
-    if (!syntaxIsJson) {
-      return;
-    }
-        
-    BaseType baseType = property.getDataType() != null ? property.getDataType().getBaseType() : null;
-    Optional<String> specifiedExample = findSpecifiedExample(property);
-    renderExample(ip, getExampleFromType(null, baseType, specifiedExample));
-  }
-  
-  private static void renderExample(IndententationPrinter ip, Optional<String> optExample) {
-    optExample.ifPresent(example -> {
-      ip.add("example:");
-      ip.pushNextLevel();
-      String yaml = JsonToYamlHelper.jsonToYaml(example);
-      Stream.of(yaml.split("\n"))
-        .skip(1) // ----- header
-        .forEach(ip::add);
-      ip.popLevel();
-    });
-  }
-  
-  private static Optional<String> getExampleFromType(DataType dataType, BaseType baseType, Optional<String> specifiedExample) {
-    if (baseType == null) {
-      return Optional.empty();
-    }
-    
-    if (BaseType.object == baseType
-        && dataType != null
-        && dataType.getBaseType() == BaseType.object
-        && dataType.getExample() != null) {
-      return Optional.of(dataType.getExample().getBody());
-    } else {
-      return specifiedExample;
-    }
-  }
-
-  private static Optional<String> findSpecifiedExample(Property property) {
-    String example = null;
-
-    JavaDoc.JavaDocTagList tags = property.getJavaDoc().get("documentationExample");
-    if (tags != null && !tags.isEmpty()) {
-      String tag = tags.get(0).trim();
-      example = tag.isEmpty() ? null : tag;
+    public boolean doRemoveObjectPrefix() {
+        return removeObjectPrefix;
     }
 
-    DocumentationExample documentationExample = property.getAnnotation(DocumentationExample.class);
-    if (documentationExample != null) {
-      if (documentationExample.exclude()) {
-        return Optional.empty();
-      }
-
-      example = documentationExample.value();
-      example = "##default".equals(example) ? null : example;
+    private static String getBaseType(DataType datatype) {
+        switch (datatype.getBaseType()) {
+            case bool:
+                return "boolean";
+            case number:
+                return "number";
+            case string:
+                return "string";
+            default:
+                return "object";
+        }
     }
 
-    if (example != null && (property.getDataType() == null || property.getDataType().getBaseType() == BaseType.string)) {
-      example = new String(new JsonStringEncoder().quoteAsString(example));
+    private void addOptionalEnum(IndententationPrinter ip, DataType datatype) {
+        List<? extends Value> values = datatype.getValues();
+        if (values == null || values.isEmpty()) {
+            return;
+        }
+
+        List<String> enums = values.stream()
+                .map(Value::getValue)
+                .collect(toList());
+        renderEnum(ip, enums);
     }
 
-    return Optional.ofNullable(example);
-  }
+    public void renderEnum(IndententationPrinter ip, List<String> values) {
+        ip.add("enum:");
+        ip.nextLevel();
+        for (String e : values) {
+            ip.item(e);
+        }
+        ip.prevLevel();
+    }
+
+    private void addOptionalProperties(IndententationPrinter ip, DataType datatype, boolean syntaxIsJson) {
+        List<? extends Property> properties = datatype.getProperties();
+        if (properties == null || properties.isEmpty()) {
+            return;
+        }
+
+        ip.add("properties:");
+        ip.nextLevel();
+        for (Property p : properties) {
+            addProperty(ip, datatype, p, syntaxIsJson);
+        }
+        ip.prevLevel();
+    }
+
+    private void addProperty(IndententationPrinter ip, DataType datatype, Property p, boolean syntaxIsJson) {
+        logger.info(" adding property " + p.getName() + " with annotations " + p.getAnnotations().keySet());
+
+        ip.add(p.getName(), ":");
+        ip.nextLevel();
+        if (datatype.getPropertyMetadata().containsKey("namespaceInfo")) {
+            addNamespaceXml(ip, p);
+        }
+
+        addOptionalNullable(ip, p);
+
+        addConstraints(ip, p);
+        if (p.isReadOnly()) {
+            ip.add("readOnly: ", Boolean.toString(p.isReadOnly()));
+        }
+
+        datatypeRefRenderer.render(ip, p.getDataType(), p.getDescription());
+
+        addOptionalPropertyExample(ip, p, syntaxIsJson);
+        addPassThroughAnnotations(ip, p);
+
+        ip.prevLevel();
+    }
+
+    private void addPassThroughAnnotations(IndententationPrinter ip, Property p) {
+        List<String> annotations = p.getAnnotations().entrySet().stream()
+                .filter(e -> passThroughAnnotations.contains(e.getKey()))
+                .map(e -> renderAnnotation(e.getKey(), e.getValue().getElementValues()))
+                .peek(s -> logger.info("  with " + s))
+                .collect(toList());
+
+        if (!annotations.isEmpty()) {
+            ip.add("x-annotations:");
+            ip.nextLevel();
+            annotations.forEach(a -> ip.add("- '", a, "'"));
+            ip.prevLevel();
+        }
+    }
+
+    private String renderAnnotation(String annotationName, Map<? extends ExecutableElement, ? extends AnnotationValue> annotationOptions) {
+        StringBuilder sb = new StringBuilder("@")
+                .append(annotationName);
+        if (!annotationOptions.isEmpty()) {
+            String args = annotationOptions.entrySet().stream()
+                    .map(e -> {
+                        String n = e.getKey().toString().replace("()", "");
+                        String v = e.getValue().toString();
+                        return n + "=" + v;
+                    })
+                    .collect(joining(", "));
+
+            sb.append("(").append(args).append(")");
+        }
+        return sb.toString();
+    }
+
+    private static void addConstraints(IndententationPrinter ip, Property p) {
+        List<ContainerType> containers = p.getDataType().getContainers();
+        boolean isArray = containers != null && !containers.isEmpty();
+
+        Max max = p.getAnnotation(Max.class);
+        DecimalMax decimalMax = p.getAnnotation(DecimalMax.class);
+        if (max != null) {
+            ip.add("maximum: ", Long.toString(max.value()));
+        } else if (decimalMax != null) {
+            ip.add("maximum: ", decimalMax.value());
+            ip.add("exclusiveMaximum: ", Boolean.toString(!decimalMax.inclusive()));
+        }
+
+        Min min = p.getAnnotation(Min.class);
+        DecimalMin decimalMin = p.getAnnotation(DecimalMin.class);
+        if (min != null) {
+            ip.add("minimum: ", Long.toString(min.value()));
+        } else if (decimalMin != null) {
+            ip.add("minimum: ", decimalMin.value());
+            ip.add("exclusiveMinimum: ", Boolean.toString(!decimalMin.inclusive()));
+        }
+
+        Size size = p.getAnnotation(Size.class);
+        if (size != null) {
+            if (isArray) {
+                ip.add("maxItems: ", Integer.toString(size.max()));
+                ip.add("minItems: ", Integer.toString(size.min()));
+            } else {
+                ip.add("maxLength: ", Integer.toString(size.max()));
+                ip.add("minLength: ", Integer.toString(size.min()));
+            }
+        }
+
+        Pattern mustMatchPattern = p.getAnnotation(Pattern.class);
+        if (mustMatchPattern != null) {
+            ip.add("pattern: ", mustMatchPattern.regexp());
+        }
+    }
+
+    private void addOptionalNullable(IndententationPrinter ip, Property p) {
+        getNillable(p).ifPresent(isNullable -> {
+            if (!TypeHelper.renderAsSimpleRef(p.getDataType())) {
+                ip.add("nullable: ", isNullable);
+            }
+        });
+    }
+
+    private void addNamespaceXml(IndententationPrinter ip, Property p) {
+        PropertyMetadata metadata = AccessorProperty.getMetadata(p);
+        if (metadata == null) {
+            return;
+        }
+
+        Optional<String> wrappedName = getWrappedName(p);
+        String namespace = metadata.getTitle();
+
+        boolean renderAttribute = AccessorProperty.isAttribute(p);
+        boolean renderNamespace = namespace != null && !namespace.isEmpty();
+
+        if (!wrappedName.isPresent() && !renderAttribute && !renderNamespace) {
+            return;
+        }
+
+        ip.add("xml:");
+        ip.nextLevel();
+        wrappedName.ifPresent(name -> {
+            ip.add("name: ", name);
+            ip.add("wrapped: true");
+        });
+        if (renderAttribute) {
+            ip.add("attribute: ", Boolean.TRUE.toString());
+        }
+        if (renderNamespace) {
+            ip.add("namespace: ", namespace);
+        }
+        ip.prevLevel();
+    }
+
+    private Optional<String> getWrappedName(Property p) {
+        return getAttributeValue(p, "javax.xml.bind.annotation.XmlElementWrapper", "name()");
+    }
+
+    private Optional<String> getNillable(Property p) {
+        return getAttributeValue(p, "javax.xml.bind.annotation.XmlElement", "nillable()");
+    }
+
+    private Optional<String> getAttributeValue(Property p, String annotationName, String propertyName) {
+        return p.getAnnotations().entrySet().stream()
+                .filter(e -> annotationName.equals(e.getKey()))
+                .flatMap(am -> am.getValue().getElementValues().entrySet().stream())
+                .filter(e -> propertyName.equals(e.getKey().toString()))
+                .map(e -> e.getValue().getValue())
+                .filter(Objects::nonNull)
+                .map(Objects::toString)
+                .findFirst();
+    }
+
+    private void addOptionalXml(IndententationPrinter ip, DataType datatype) {
+        String xmlName = getNonNullAndNonEmpty(AccessorDataType.getXmlName(datatype));
+
+        Namespace namespace = datatype.getNamespace();
+        String xmlNamespace = getNonNullAndNonEmpty(namespace != null ? namespace.getUri() : null);
+
+        logger.debug("optionalXml for " + datatype.getLabel() + " : " + xmlName + " / " + xmlNamespace);
+
+        if (xmlName != null || xmlNamespace != null) {
+            ip.add("xml:");
+            ip.nextLevel();
+            if (xmlName != null) {
+                ip.add("name: ", xmlName);
+            }
+            if (xmlNamespace != null) {
+                ip.add("namespace: ", xmlNamespace);
+            }
+            ip.prevLevel();
+        }
+    }
+
+    private static String getNonNullAndNonEmpty(String str) {
+        if (str == null) {
+            return null;
+        }
+        return str.isEmpty() ? null : str;
+    }
+
+    private static void addOptionalExample(IndententationPrinter ip, DataType datatype, boolean syntaxIsJson) {
+        if (!syntaxIsJson) {
+            return;
+        }
+
+        renderExample(ip, getExampleFromType(datatype, datatype.getBaseType(), Optional.empty()));
+    }
+
+    private static void addOptionalPropertyExample(IndententationPrinter ip, Property property, boolean syntaxIsJson) {
+        if (!syntaxIsJson) {
+            return;
+        }
+
+        BaseType baseType = property.getDataType() != null ? property.getDataType().getBaseType() : null;
+        Optional<String> specifiedExample = findSpecifiedExample(property);
+        renderExample(ip, getExampleFromType(null, baseType, specifiedExample));
+    }
+
+    private static void renderExample(IndententationPrinter ip, Optional<String> optExample) {
+        optExample.ifPresent(example -> {
+            ip.add("example:");
+            ip.pushNextLevel();
+            String yaml = JsonToYamlHelper.jsonToYaml(example);
+            Stream.of(yaml.split("\n"))
+                    .skip(1) // ----- header
+                    .forEach(ip::add);
+            ip.popLevel();
+        });
+    }
+
+    private static Optional<String> getExampleFromType(DataType dataType, BaseType baseType, Optional<String> specifiedExample) {
+        if (baseType == null) {
+            return Optional.empty();
+        }
+
+        if (BaseType.object == baseType
+                && dataType != null
+                && dataType.getBaseType() == BaseType.object
+                && dataType.getExample() != null) {
+            return Optional.of(dataType.getExample().getBody());
+        } else {
+            return specifiedExample;
+        }
+    }
+
+    private static Optional<String> findSpecifiedExample(Property property) {
+        String example = null;
+
+        JavaDoc.JavaDocTagList tags = property.getJavaDoc().get("documentationExample");
+        if (tags != null && !tags.isEmpty()) {
+            String tag = tags.get(0).trim();
+            example = tag.isEmpty() ? null : tag;
+        }
+
+        DocumentationExample documentationExample = property.getAnnotation(DocumentationExample.class);
+        if (documentationExample != null) {
+            if (documentationExample.exclude()) {
+                return Optional.empty();
+            }
+
+            example = documentationExample.value();
+            example = "##default".equals(example) ? null : example;
+        }
+
+        if (example != null && (property.getDataType() == null || property.getDataType().getBaseType() == BaseType.string)) {
+            example = new String(new JsonStringEncoder().quoteAsString(example));
+        }
+
+        return Optional.ofNullable(example);
+    }
 }

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/OpenApiModule.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/OpenApiModule.java
@@ -206,8 +206,8 @@ public class OpenApiModule extends BasicGeneratingModule implements ApiFeaturePr
       
       
       EnunciateLogger logger = enunciate.getLogger();
-      DataTypeReferenceRenderer dataTypeReferenceRenderer = new DataTypeReferenceRenderer(logger);
-      ObjectTypeRenderer objectTypeRenderer = new ObjectTypeRenderer(logger, dataTypeReferenceRenderer, getPassThroughAnnotations());
+      DataTypeReferenceRenderer dataTypeReferenceRenderer = new DataTypeReferenceRenderer(logger, doRemoveObjectPrefix());
+      ObjectTypeRenderer objectTypeRenderer = new ObjectTypeRenderer(logger, dataTypeReferenceRenderer, getPassThroughAnnotations(), doRemoveObjectPrefix());
       
       dir.mkdirs();
       Map<String, Object> model = new HashMap<>();
@@ -226,6 +226,16 @@ public class OpenApiModule extends BasicGeneratingModule implements ApiFeaturePr
         throw new EnunciateException(e);
       }
     }
+  }
+
+  /**
+   * By default all model objects are prefixed with "json_" in output file openapi.yml.
+   * When this configuration property has value <code>true</code>, then this prefix is omitted.
+   *
+   * Having the prefix caused problems with client code generation.
+   */
+  private boolean doRemoveObjectPrefix() {
+    return Boolean.valueOf(config.getString("[@removeObjectPrefix]"));
   }
 
   protected String getHost() {
@@ -397,6 +407,7 @@ public class OpenApiModule extends BasicGeneratingModule implements ApiFeaturePr
   }
   
   public File getDocsDir() {
+
     String docsDir = config.getString("[@docsDir]");
     if (docsDir != null) {
       return resolveFile(docsDir);

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/components/SchemaRenderer.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/components/SchemaRenderer.java
@@ -45,7 +45,7 @@ public class SchemaRenderer extends Typed1ArgTemplateMethod<String, String> {
 
   @Override
   protected String exec(String nextLineIndent) {
-    IndententationPrinter ip = new IndententationPrinter(nextLineIndent);
+    IndententationPrinter ip = new IndententationPrinter(nextLineIndent, objectTypeRenderer.doRemoveObjectPrefix());
     renderLines(ip);
     return ip.toString();
   }

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/paths/ExampleRenderer.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/paths/ExampleRenderer.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,28 +26,31 @@ import dk.jyskebank.tools.enunciate.modules.openapi.yaml.JsonToYamlHelper;
 import dk.jyskebank.tools.enunciate.modules.openapi.yaml.YamlHelper;
 
 public class ExampleRenderer extends Typed1ArgTemplateMethod<String, String> {
-  @SuppressWarnings("unused") private final EnunciateLogger logger;
-  private final Example example;
+    @SuppressWarnings("unused")
+    private final EnunciateLogger logger;
+    private final Example example;
+    private final boolean removeObjectPrefix;
 
-  public ExampleRenderer(EnunciateLogger logger, Example example) {
-    super(String.class);
-    this.logger = logger;
-    this.example = example;
-  }
-
-  @Override
-  protected String exec(String nextLineIndent) {
-    IndententationPrinter ip = new IndententationPrinter(nextLineIndent);
-
-    if ("js".equals(example.getLang())) {
-      String yaml = JsonToYamlHelper.jsonToYaml(example.getBody());
-      Stream.of(yaml.split("\n"))
-        .skip(1) // ----- header
-        .forEach(ip::add);
-    } else {
-      ip.add(YamlHelper.safeYamlString(example.getBody()));
+    public ExampleRenderer(EnunciateLogger logger, Example example, boolean removeObjectPrefix) {
+        super(String.class);
+        this.logger = logger;
+        this.example = example;
+        this.removeObjectPrefix = removeObjectPrefix;
     }
-    
-    return ip.toString();
-  }
+
+    @Override
+    protected String exec(String nextLineIndent) {
+        IndententationPrinter ip = new IndententationPrinter(nextLineIndent, removeObjectPrefix);
+
+        if ("js".equals(example.getLang())) {
+            String yaml = JsonToYamlHelper.jsonToYaml(example.getBody());
+            Stream.of(yaml.split("\n"))
+                    .skip(1) // ----- header
+                    .forEach(ip::add);
+        } else {
+            ip.add(YamlHelper.safeYamlString(example.getBody()));
+        }
+
+        return ip.toString();
+    }
 }

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/paths/ParameterRenderer.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/paths/ParameterRenderer.java
@@ -42,7 +42,7 @@ public class ParameterRenderer extends Typed1ArgTemplateMethod<String, String> {
 
   @Override
   protected String exec(String nextLineIndent) {
-    IndententationPrinter ip = new IndententationPrinter(nextLineIndent);
+    IndententationPrinter ip = new IndententationPrinter(nextLineIndent, dataTypeReferenceRenderer.doRemoveObjectPrefix());
 
     addOptionalEnum(ip);
     addType(ip);

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/paths/RequestEntityRenderer.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/paths/RequestEntityRenderer.java
@@ -42,7 +42,7 @@ public class RequestEntityRenderer extends Typed1ArgTemplateMethod<String, Strin
   
   @Override
   protected String exec(String nextLineIndent) {
-      IndententationPrinter ip = new IndententationPrinter(nextLineIndent);
+      IndententationPrinter ip = new IndententationPrinter(nextLineIndent, dataTypeReferenceRenderer.doRemoveObjectPrefix());
 
       ip.add(safeYamlString(mediaWithFallback), ":");
       ip.nextLevel();

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/paths/Response.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/paths/Response.java
@@ -46,7 +46,7 @@ public class Response {
     this.headers = headers;
     this.description = YamlHelper.safeYamlString(description);
     renderer = new ResponseDataTypeRenderer(logger, dataTypeReferenceRenderer, dataType, description);
-    exampleRenderer = optionalExample.map(e -> new ExampleRenderer(logger, e));
+    exampleRenderer = optionalExample.map(e -> new ExampleRenderer(logger, e, dataTypeReferenceRenderer.doRemoveObjectPrefix()));
     
     // TODO: Render headers
   }

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/paths/ResponseDataTypeRenderer.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/paths/ResponseDataTypeRenderer.java
@@ -38,7 +38,7 @@ public class ResponseDataTypeRenderer extends Typed1ArgTemplateMethod<String, St
 
   @Override
   protected String exec(String nextLineIndent) {
-    IndententationPrinter ip = new IndententationPrinter(nextLineIndent);
+    IndententationPrinter ip = new IndententationPrinter(nextLineIndent, dataTypeReferenceRenderer.doRemoveObjectPrefix());
 
     dataTypeReferenceRenderer.render(ip, dataType, description);
     return ip.toString();

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/yaml/IndententationPrinter.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/yaml/IndententationPrinter.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,6 +15,8 @@
  */
 package dk.jyskebank.tools.enunciate.modules.openapi.yaml;
 
+import org.apache.commons.lang.StringUtils;
+
 import java.util.ArrayDeque;
 import java.util.Deque;
 
@@ -22,90 +24,101 @@ import java.util.Deque;
  * Printer helping keep track of YAML indentation levels.
  */
 public class IndententationPrinter {
-  private static final String DOS_NEWLINE = "\r\n";
-  private static final String SEQUENCE_PREFIX = "- ";
-  private final StringBuilder sb = new StringBuilder();
-  private Deque<IndentLevel> indentLevelStack = new ArrayDeque<>();
-  private Deque<IndentLevel> memoryStack = new ArrayDeque<>();
-  private boolean itemFollows;
+    private static final String DOS_NEWLINE = "\r\n";
+    private static final String SEQUENCE_PREFIX = "- ";
+    public static final String JSON_ = "json_";
+    private final StringBuilder sb = new StringBuilder();
+    private Deque<IndentLevel> indentLevelStack = new ArrayDeque<>();
+    private Deque<IndentLevel> memoryStack = new ArrayDeque<>();
+    private boolean itemFollows;
+    private boolean removeObjectPrefix;
 
-  public IndententationPrinter(String initialIndentation) {
-    indentLevelStack.push(new IndentLevel(initialIndentation));
-  }
-
-  private IndentLevel getActive() {
-    return indentLevelStack.peek();
-  }
-
-  public void itemFollows() {
-    this.itemFollows = true;
-  }
-  
-  public IndententationPrinter item(String... lines) {
-    itemFollows = true;
-    return add(lines);
-  }
-
-  public IndententationPrinter add(String... lines) {
-    addIndentationForAllButFirstLine();
-    for (String line : lines) {
-      sb.append(line);
+    public IndententationPrinter(String initialIndentation, boolean removeObjectPrefix) {
+        this.removeObjectPrefix = removeObjectPrefix;
+        indentLevelStack.push(new IndentLevel(initialIndentation));
     }
-    return this;
-  }
 
-  private void addIndentationForAllButFirstLine() {
-    if (sb.length() != 0) {
-      String indent = getActive().indentation;
-      if (itemFollows) {
-        indent = indent.replaceAll("  $", SEQUENCE_PREFIX);
-        itemFollows = false;
-      }
-      sb.append(DOS_NEWLINE).append(indent);
+    private IndentLevel getActive() {
+        return indentLevelStack.peek();
     }
-  }
-  
-  public IndententationPrinter nextLevel() {
-    indentLevelStack.push(getActive().next());
-    return this;
-  }
 
-  public IndententationPrinter prevLevel() {
-    if (indentLevelStack.size() == 1) {
-      throw new IllegalStateException("Cannot go beyond initial indentation");
+    public void itemFollows() {
+        this.itemFollows = true;
     }
-    indentLevelStack.pop();
-    return this;
-  }
 
-  public IndententationPrinter pushNextLevel() {
-    memoryStack.push(getActive());
-    return nextLevel();
-  }
-  
-  public IndententationPrinter popLevel() {
-    IndentLevel revertTo = memoryStack.pop();
-    while (indentLevelStack.peek() != revertTo) {
-      indentLevelStack.pop();
+    public IndententationPrinter item(String... lines) {
+        itemFollows = true;
+        return add(lines);
     }
-    return this;
-  }
-  
-  public String toString() {
-    return sb.toString();
-  }
 
-  public static class IndentLevel {
-    private static final String INDENT_PREFIX = "  ";
+    public IndententationPrinter add(String... lines) {
+        addIndentationForAllButFirstLine();
+        for (String line : lines) {
+            if (removeObjectPrefix) {
+                sb.append(removeJsonPrefix(line));
+            } else {
+                sb.append(line);
+            }
+        }
+        return this;
+    }
 
-    public final String indentation;
-    
-    public IndentLevel(String indentation) {
-      this.indentation = indentation;
+    private String removeJsonPrefix(String line) {
+        return StringUtils.remove(line, JSON_);
     }
-    
-    public IndentLevel next() {
-      return new IndentLevel(indentation.replace('-', ' ') + INDENT_PREFIX);
+
+    private void addIndentationForAllButFirstLine() {
+        if (sb.length() != 0) {
+            String indent = getActive().indentation;
+            if (itemFollows) {
+                indent = indent.replaceAll("  $", SEQUENCE_PREFIX);
+                itemFollows = false;
+            }
+            sb.append(DOS_NEWLINE).append(indent);
+        }
     }
-  }
+
+    public IndententationPrinter nextLevel() {
+        indentLevelStack.push(getActive().next());
+        return this;
+    }
+
+    public IndententationPrinter prevLevel() {
+        if (indentLevelStack.size() == 1) {
+            throw new IllegalStateException("Cannot go beyond initial indentation");
+        }
+        indentLevelStack.pop();
+        return this;
+    }
+
+    public IndententationPrinter pushNextLevel() {
+        memoryStack.push(getActive());
+        return nextLevel();
+    }
+
+    public IndententationPrinter popLevel() {
+        IndentLevel revertTo = memoryStack.pop();
+        while (indentLevelStack.peek() != revertTo) {
+            indentLevelStack.pop();
+        }
+        return this;
+    }
+
+    public String toString() {
+        return sb.toString();
+    }
+
+    public static class IndentLevel {
+        private static final String INDENT_PREFIX = "  ";
+
+        public final String indentation;
+
+        public IndentLevel(String indentation) {
+            this.indentation = indentation;
+        }
+
+        public IndentLevel next() {
+            return new IndentLevel(indentation.replace('-', ' ') + INDENT_PREFIX);
+        }
+    }
 }


### PR DESCRIPTION
Add attribute 'removeObjectPrefix' to openapi module.
Without this attribute the old behaviour is preserved, i.e.
with 'json_' prefix.

Only when this attribute has value 'true' the new behaviour takes
effect, e.g. Objects have no prefix.