### PR TITLE
Generate 'oneOf' in openapi.yml for abstract classes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ ext {
 
 	junitPlatformVersion = '1.5.1'
 	junitJupiterVersion = '5.5.1'
+	mockitoVersion = '3.0.0'
 	
 	jbNexus = System.getenv('NEXUS_REPO_URL')
 	publicVersion = version.replaceAll("([V-])0(\\d)", '$1$2').replace("V", "").replace("-", ".")
@@ -62,6 +63,7 @@ dependencies {
    	testCompile "org.assertj:assertj-core:3.12.2"
 	testCompile("org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}")
 	testCompile("org.junit.platform:junit-platform-runner:${junitPlatformVersion}")
+	testCompile("org.mockito:mockito-core:${mockitoVersion}")
 	testRuntime("org.junit.jupiter:junit-jupiter-engine:${junitJupiterVersion}")
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,13 @@
             <version>${junitJupiterVersion}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.0.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/ObjectTypeRenderer.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/ObjectTypeRenderer.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -69,6 +69,24 @@ public class ObjectTypeRenderer {
     public void render(IndententationPrinter ip, DataType datatype, boolean syntaxIsJson) {
         logger.info("Rendering type " + datatype.getLabel());
         ip.pushNextLevel();
+
+        if (datatype.isAbstract()) {
+            ip.add("oneOf: ", "");
+            for (DataTypeReference subType : datatype.getSubtypes()) {
+                addSchemaSlugReference(ip, subType.getSlug());
+            }
+        } else {
+            renderConcreteType(ip, datatype, syntaxIsJson);
+        }
+
+        ip.popLevel();
+    }
+
+    private static void addSchemaSlugReference(IndententationPrinter ip, String slug) {
+        ip.add("- $ref: \"#/components/schemas/" + slug + "\"");
+    }
+
+    private void renderConcreteType(IndententationPrinter ip, DataType datatype, boolean syntaxIsJson) {
         ip.add("title: ", safeYamlString(datatype.getLabel()));
         addOptionalSupertypeHeader(ip, datatype);
 
@@ -79,8 +97,6 @@ public class ObjectTypeRenderer {
         addOptionalXml(ip, datatype);
 
         addOptionalExample(ip, datatype, syntaxIsJson);
-
-        ip.popLevel();
     }
 
     private void addOptionalSupertypeHeader(IndententationPrinter ip, DataType datatype) {

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/ObjectTypeRenderer.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/ObjectTypeRenderer.java
@@ -53,6 +53,7 @@ import dk.jyskebank.tools.enunciate.modules.openapi.yaml.IndententationPrinter;
 import dk.jyskebank.tools.enunciate.modules.openapi.yaml.JsonToYamlHelper;
 
 public class ObjectTypeRenderer {
+    public static final String JSON_REF_FORMAT = "- $ref: \"#/components/schemas/%s\"";
     private final EnunciateLogger logger;
     private final DataTypeReferenceRenderer datatypeRefRenderer;
     private final Set<String> passThroughAnnotations;
@@ -83,7 +84,7 @@ public class ObjectTypeRenderer {
     }
 
     private static void addSchemaSlugReference(IndententationPrinter ip, String slug) {
-        ip.add("- $ref: \"#/components/schemas/" + slug + "\"");
+        ip.add(String.format(JSON_REF_FORMAT, slug));
     }
 
     private void renderConcreteType(IndententationPrinter ip, DataType datatype, boolean syntaxIsJson) {

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/ObjectTypeRendererTest.java
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/ObjectTypeRendererTest.java
@@ -1,0 +1,115 @@
+package dk.jyskebank.tools.enunciate.modules.openapi;
+
+import com.webcohesion.enunciate.api.datatype.BaseType;
+import com.webcohesion.enunciate.api.datatype.DataType;
+import com.webcohesion.enunciate.api.datatype.DataTypeReference;
+import dk.jyskebank.tools.enunciate.modules.openapi.yaml.IndententationPrinter;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static dk.jyskebank.tools.enunciate.modules.openapi.ObjectTypeRenderer.JSON_REF_FORMAT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ObjectTypeRendererTest {
+
+    public static final String INITIAL_INDENTATION = "x";
+    public static final String CONCRETE_TYPE_LABEL = "ConcreteX";
+
+    @Test
+    void verifyRenderAbstractType() {
+
+        ObjectTypeRenderer objectTypeRenderer = new ObjectTypeRenderer(new OutputLogger(), null
+                , null, false);
+
+        IndententationPrinter ip = getIndentationPrinter();
+        DataType abstractType = getAbstractTypeWithTwoSubtypes();
+
+        objectTypeRenderer.render(ip, abstractType, true);
+
+        final String expected = createExpectedResultForAbstractType();
+        assertEquals(expected, ip.toString());
+
+    }
+
+    @Test
+    void verifyRenderConcreteType() {
+        ObjectTypeRenderer objectTypeRenderer = new ObjectTypeRenderer(new OutputLogger(), null
+                , null, false);
+
+        IndententationPrinter ip = getIndentationPrinter();
+        DataType concreteType = getConcreteType();
+
+        objectTypeRenderer.render(ip, concreteType, false);
+
+        final String expected = createExpectedResultForConcreteType();
+        assertEquals(expected, ip.toString());
+
+    }
+
+    private String createExpectedResultForConcreteType() {
+        String DOS_NEWLINE = "\r\n";
+        return String.format("title: \"%s\"%s%s  type: string",
+                CONCRETE_TYPE_LABEL,
+                DOS_NEWLINE,
+                INITIAL_INDENTATION);
+    }
+
+    private DataType getConcreteType() {
+        DataType mockedDataType = mock(DataType.class);
+        when(mockedDataType.isAbstract()).thenReturn(Boolean.FALSE);
+
+        when(mockedDataType.getLabel()).thenReturn(CONCRETE_TYPE_LABEL);
+        when(mockedDataType.getBaseType()).thenReturn(BaseType.string);
+
+        when(mockedDataType.getSubtypes()).thenReturn(Collections.emptyList());
+        when(mockedDataType.getProperties()).thenReturn(Collections.emptyList());
+        when(mockedDataType.getValues()).thenReturn(Collections.emptyList());
+
+        return mockedDataType;
+    }
+
+    private String createExpectedResultForAbstractType() {
+        String DOS_NEWLINE = "\r\n";
+        return String.format("oneOf: %s%s  %s%s%s  %s",
+                DOS_NEWLINE,
+                INITIAL_INDENTATION,
+                getJsonRefForSubType("A"),
+                DOS_NEWLINE,
+                INITIAL_INDENTATION,
+                getJsonRefForSubType("B"));
+    }
+
+    private String getJsonRefForSubType(String a) {
+        return String.format(JSON_REF_FORMAT, a);
+    }
+
+    private IndententationPrinter getIndentationPrinter() {
+        return new IndententationPrinter(INITIAL_INDENTATION, false);
+    }
+
+    private DataType getAbstractTypeWithTwoSubtypes() {
+
+        DataType mockedDataType = mock(DataType.class);
+        when(mockedDataType.isAbstract()).thenReturn(Boolean.TRUE);
+
+        List<DataTypeReference> subTypes = new ArrayList<>();
+        subTypes.add(createConcreteSubtype("A"));
+        subTypes.add(createConcreteSubtype("B"));
+
+        when(mockedDataType.getSubtypes()).thenReturn(subTypes);
+
+        return mockedDataType;
+    }
+
+    private DataTypeReference createConcreteSubtype(String nameOfConcreteType) {
+        DataTypeReference concreteTypeA = mock(DataTypeReference.class);
+        when(concreteTypeA.getSlug()).thenReturn(nameOfConcreteType);
+        return concreteTypeA;
+    }
+}
+

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/oneof/Cat.java
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/oneof/Cat.java
@@ -1,0 +1,15 @@
+package dk.jyskebank.tools.enunciate.modules.openapi.oneof;
+
+public class Cat implements Pet {
+
+    private boolean famousOnYouTube;
+
+    public boolean isFamousOnYouTube() {
+        return famousOnYouTube;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+}

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/oneof/DataDTO.java
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/oneof/DataDTO.java
@@ -1,0 +1,17 @@
+package dk.jyskebank.tools.enunciate.modules.openapi.oneof;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+@JsonRootName("oneOfSupport")
+public class DataDTO {
+
+   private Pet pet;
+
+   public Pet getPet() {
+      return pet;
+   }
+
+   public void setPet(Pet pet) {
+      this.pet = pet;
+   }
+}

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/oneof/DataResource.java
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/oneof/DataResource.java
@@ -1,0 +1,47 @@
+package dk.jyskebank.tools.enunciate.modules.openapi.oneof;
+
+import com.webcohesion.enunciate.metadata.rs.*;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+
+@ResourceGroup("Data")
+@RequestHeaders({ // Common headers
+	@RequestHeader(name = "userid", description = "The actual user performing the operation") 
+})
+@StatusCodes({ // Common response codes
+	@ResponseCode(code = 400, condition = "Bad request, inspect response payload for error details", type=@TypeHint(Messages.class)),
+	@ResponseCode(code = 401, condition = "Unauthorized, please provide valid Authentication header", type=@TypeHint(Messages.class)),
+	@ResponseCode(code = 403, condition = "Forbidden, user does not have permission", type=@TypeHint(Messages.class)),
+	@ResponseCode(code = 404, condition = "Not Found, inspect response for more info", type=@TypeHint(Messages.class)),
+	@ResponseCode(code = 500, condition = "Internal Server Error, Unexpected server error", type=@TypeHint(Messages.class))
+})
+
+@Path("/data/{pathArg}")
+public class DataResource {
+
+	/**
+	 * Summary.
+	 *
+	 * Description follows...
+	 *
+	 * @param pathArg
+	 *            The id of the customer
+	 */
+	@StatusCodes({
+			@ResponseCode(code = 201, condition = "Created, Consents created", type=@TypeHint(dk.jyskebank.tools.enunciate.modules.openapi.oneof.DataDTO.class)),
+			@ResponseCode(code = 204, condition = "No Content, Current consents updated")
+	})
+
+	@POST
+	@Produces(MediaType.APPLICATION_JSON)
+	@Consumes(MediaType.APPLICATION_JSON)
+	public Response update(@PathParam("pathArg") String pathArg, @NotNull(message = "Mandatory consents payload is missing") @Valid DataDTO customerDTO) {
+		return Response.ok(new DataDTO()).build();
+	}
+
+}

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/oneof/Dog.java
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/oneof/Dog.java
@@ -1,0 +1,15 @@
+package dk.jyskebank.tools.enunciate.modules.openapi.oneof;
+
+public class Dog implements Pet {
+
+    private boolean aggressive;
+
+    public boolean isAggressive() {
+        return aggressive;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+}

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/oneof/Messages.java
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/oneof/Messages.java
@@ -1,0 +1,48 @@
+package dk.jyskebank.tools.enunciate.modules.openapi.oneof;
+
+import org.codehaus.jackson.annotate.JsonIgnore;
+import org.codehaus.jackson.map.ObjectMapper;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+
+@XmlRootElement
+public class Messages {
+	
+	private List<String> messages = new ArrayList<String>();
+	
+	public List<String> getMessages() {
+		return messages;
+	}
+	
+	public void setMessages(List<String> messages) {
+		this.messages = messages;
+	}
+
+	public void add(String newMessage) {
+		if (messages.stream().anyMatch(m -> m.equals(newMessage))) {
+			return;
+		}
+		this.messages.add(newMessage);
+	}
+
+	@JsonIgnore
+	public boolean isNotOk() {
+		return messages.stream().anyMatch(m -> "error".equals(m));
+	}
+
+	@JsonIgnore
+	public boolean isOK() {
+		return !isNotOk();
+	}
+
+	@Override
+	public String toString() {
+		try {
+			return new ObjectMapper().writeValueAsString(this).toString();
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/oneof/Pet.java
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/oneof/Pet.java
@@ -1,0 +1,5 @@
+package dk.jyskebank.tools.enunciate.modules.openapi.oneof;
+
+public interface Pet {
+    String getName();
+}

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/oneof/enunciate.xml
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/oneof/enunciate.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<enunciate version="version from enunciate.xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://enunciate.webcohesion.com/schemas/enunciate-2.11.1.xsd">
+	<title>Title from enunciate.xml</title>
+	<description>Description from enunciate.xml. Can contain weird letters æøåÆØÅ</description>
+
+	<modules disabledByDefault="true">
+		<openapi disabled="false" skipBase="false" />
+		<jaxrs groupBy="annotation" disabled="false" />
+		<jackson disabled="false" />
+		<jaxb disabled="false" />
+		<jaxrs disabled="false" />
+	</modules>
+</enunciate>

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/oneof/openapi.yml
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/oneof/openapi.yml
@@ -1,0 +1,138 @@
+openapi: 3.0.0
+info:
+  title: "Title from enunciate.xml"
+  version: "version from enunciate.xml"
+  description: "Description from enunciate.xml. Can contain weird letters æøåÆØÅ"
+servers: []
+paths:
+  "/data/{pathArg}":
+    post:
+      description: "Summary.\n\nDescription follows..."
+      tags:
+        - "Data"
+      summary: "Summary."
+      deprecated: false
+      operationId: update
+      parameters:
+      - name: "userid"
+        in: header
+        description: "The actual user performing the operation"
+        required: false
+        schema:
+          type: string
+        style: simple
+      - name: "pathArg"
+        in: path
+        description: "The id of the customer"
+        required: true
+        schema:
+          type: string
+        style: simple
+      requestBody:
+        description: ""
+        required: true
+        content:
+          "application/json":
+            schema:
+              $ref: "#/components/schemas/json_DataDTO"
+      responses:
+        "201":
+          description: "Created, Consents created"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/json_DataDTO"
+        "204":
+          description: "No Content, Current consents updated"
+          content:
+            "application/json":
+              schema:
+                description: "No Content, Current consents updated"
+                type: string
+                format: binary
+        "400":
+          description: "Bad request, inspect response payload for error details"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/json_Messages"
+        "401":
+          description: "Unauthorized, please provide valid Authentication header"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/json_Messages"
+        "403":
+          description: "Forbidden, user does not have permission"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/json_Messages"
+        "404":
+          description: "Not Found, inspect response for more info"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/json_Messages"
+        "500":
+          description: "Internal Server Error, Unexpected server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/json_Messages"
+ 
+components:
+  schemas:
+    "json_Cat":
+      title: "Cat"
+      type: object
+      properties:
+        famousOnYouTube:
+          type: boolean
+        name:
+          type: string
+      example:
+        famousOnYouTube: true
+        name: "..."
+    "json_Dog":
+      title: "Dog"
+      type: object
+      properties:
+        aggressive:
+          type: boolean
+        name:
+          type: string
+      example:
+        aggressive: true
+        name: "..."
+    "json_Messages":
+      title: "Messages"
+      type: object
+      properties:
+        messages:
+          type: array
+          items:
+            type: string
+        notOk:
+          type: boolean
+        OK:
+          type: boolean
+      example:
+        messages:
+        - "..."
+        - "..."
+        notOk: true
+        OK: true
+    "json_Pet":
+      oneOf: 
+      - $ref: "#/components/schemas/json_Cat"
+      - $ref: "#/components/schemas/json_Dog"
+    "json_DataDTO":
+      title: "oneOfSupport"
+      type: object
+      properties:
+        pet:
+          $ref: "#/components/schemas/json_Pet"
+      example:
+        pet:
+          name: "..."


### PR DESCRIPTION
To model an abstract class correctly in JSON schema, I would like to add JSON schem's 'oneOf' construct. 
This way, clients can see which concrete classes can be used in a request that contains a field of the abstract type.

When you generate Java client stubs from the resulting openapi.yml, a common interface is generated that
all the concrete classes implement.