### PR TITLE
Bump Enunciate to 2.12.0, plus Enunciate brings Jackson 2.9.x instead 2.5.x with update.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ defaultTasks 'dist'
 
 // Setup to use Jyske Bank Nexus if present, otherwise use Maven Central
 ext {
-	enunciateVersion = "2.11.1"
+	enunciateVersion = "2.12.0"
 
 	junitPlatformVersion = '1.5.1'
 	junitJupiterVersion = '5.5.1'
@@ -48,8 +48,8 @@ dependencies {
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.9"
     compileOnly "com.webcohesion.enunciate:enunciate-core:${enunciateVersion}"
     compileOnly "com.webcohesion.enunciate:enunciate-jaxb:${enunciateVersion}"
-    compileOnly "com.fasterxml.jackson.core:jackson-databind:2.9.9.1"
-    compileOnly 'org.freemarker:freemarker:2.3.23'
+    compileOnly "com.fasterxml.jackson.core:jackson-databind:2.9.9.3"
+    compileOnly 'org.freemarker:freemarker:2.3.28'
 
 	testCompile "org.codehaus.jackson:jackson-mapper-asl:1.9.13"
 	testCompile "org.jboss.resteasy:jaxrs-api:3.0.12.Final"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
-distributionSha256Sum=7bdbad1e4f54f13c8a78abc00c26d44dd8709d4aedb704d913fb1bb78ac025dc
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-bin.zip
+distributionSha256Sum=15c02ef5dd3631ec02ac52e8725703e0285d9a7eecbf4e5939aa9e924604d01d
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/pom.xml
+++ b/pom.xml
@@ -11,9 +11,9 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <enunciate.version>2.11.1</enunciate.version>
+        <enunciate.version>2.12.0</enunciate.version>
         <jackson.version>2.9.9</jackson.version>
-        <jacksondatabind.version>2.9.9.1</jacksondatabind.version>
+        <jacksondatabind.version>2.9.9.3</jacksondatabind.version>
         <freemarker.version>2.3.23</freemarker.version>
         <resteasy.version>3.0.12.Final</resteasy.version>
         <slf4j.version>1.7.7</slf4j.version>

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/OpenApiModule.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/OpenApiModule.java
@@ -94,7 +94,7 @@ public class OpenApiModule extends BasicGeneratingModule implements ApiFeaturePr
 
   @Override
   public List<DependencySpec> getDependencySpecifications() {
-    return Arrays.asList((DependencySpec) new DependencySpec() {
+    return Collections.singletonList(new DependencySpec() {
       @Override
       public boolean accept(EnunciateModule module) {
         return DEPENDENCY_MODULES.contains(module.getName());
@@ -142,7 +142,7 @@ public class OpenApiModule extends BasicGeneratingModule implements ApiFeaturePr
     enunciate.addArtifact(openapiArtifact);
     
     try {
-      ApiRegistrationContext registrationContext = new DefaultRegistrationContext();
+      ApiRegistrationContext registrationContext = new DefaultRegistrationContext(context);
       List<ResourceApi> resourceApis = apiRegistry.getResourceApis(registrationContext);
       new OpenApiInterfaceDescription(resourceApis, registrationContext).writeToFolder(docsDir);
     } catch (IOException e) {
@@ -169,14 +169,15 @@ public class OpenApiModule extends BasicGeneratingModule implements ApiFeaturePr
       }
 
       @Override
-      public InterfaceDescriptionFile getSwaggerUI(ApiRegistrationContext context) {
-        List<ResourceApi> resourceApis = apiRegistry.getResourceApis(context);
+      public InterfaceDescriptionFile getSwaggerUI() {
+        ApiRegistrationContext registrationContext = new DefaultRegistrationContext(context);
+        List<ResourceApi> resourceApis = apiRegistry.getResourceApis(registrationContext);
 
         if (resourceApis == null || resourceApis.isEmpty()) {
           info("No resource APIs registered: OpenApi UI will not be generated.");
         }
 
-        return new OpenApiInterfaceDescription(resourceApis, context);
+        return new OpenApiInterfaceDescription(resourceApis, registrationContext);
       }
     };
   }
@@ -235,7 +236,7 @@ public class OpenApiModule extends BasicGeneratingModule implements ApiFeaturePr
    * Having the prefix caused problems with client code generation.
    */
   private boolean doRemoveObjectPrefix() {
-    return Boolean.valueOf(config.getString("[@removeObjectPrefix]"));
+    return Boolean.parseBoolean(config.getString("[@removeObjectPrefix]"));
   }
 
   protected String getHost() {

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/yaml/YamlHelper.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/yaml/YamlHelper.java
@@ -23,7 +23,7 @@ public class YamlHelper {
   // as per http://www.yaml.org/spec/1.2/spec.html#id2776092
   private static final List<Character> VALID_CHAR_AFTER_ESCAPE = Arrays.asList('0', 'a', 'b', 't', '\t', 'n', 'v', 'f', 'r', 'e', ' ', '"', '/', '\\', 'N', '_', 'L', 'P', 'x', 'u', 'U');
   
-  public static final String safeYamlString(String str) {
+  public static String safeYamlString(String str) {
     if (str == null) {
       return null;
     }

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/arguments/openapi.yml
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/arguments/openapi.yml
@@ -56,7 +56,7 @@ paths:
         description: ""
         required: true
         content:
-          "*/*":
+          "application/octet-stream":
             schema:
               type: string
               format: binary

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/date/openapi.yml
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/date/openapi.yml
@@ -37,51 +37,25 @@ components:
             type: string
             format: date-time
           aLocalDate:
-            $ref: "#/components/schemas/xml_ns0_localDate"
+            type: string
+            format: date
           aLocalDateTime:
-            $ref: "#/components/schemas/xml_ns0_localDateTime"
+            type: string
+            format: date-time
           aLocalTime:
-            $ref: "#/components/schemas/xml_ns0_localTime"
+            type: string
           aZonedDateTime:
-            $ref: "#/components/schemas/xml_ns0_zonedDateTime"
+            type: string
+            format: date-time
           anOffsetDateTime:
-            $ref: "#/components/schemas/xml_ns0_offsetDateTime"
+            type: string
+            format: date-time
           anOffsetTime:
             $ref: "#/components/schemas/xml_ns0_offsetTime"
         xml:
           name: dataXmlDto
-    "xml_ns0_localDate":
-      title: "localDate"
-      allOf:
-      - type: string
-        format: binary
-      - type: object
-    "xml_ns0_localDateTime":
-      title: "localDateTime"
-      allOf:
-      - type: string
-        format: binary
-      - type: object
-    "xml_ns0_localTime":
-      title: "localTime"
-      allOf:
-      - type: string
-        format: binary
-      - type: object
-    "xml_ns0_offsetDateTime":
-      title: "offsetDateTime"
-      allOf:
-      - type: string
-        format: binary
-      - type: object
     "xml_ns0_offsetTime":
       title: "offsetTime"
-      allOf:
-      - type: string
-        format: binary
-      - type: object
-    "xml_ns0_zonedDateTime":
-      title: "zonedDateTime"
       allOf:
       - type: string
         format: binary

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/nillable/openapi.yml
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/nillable/openapi.yml
@@ -29,6 +29,8 @@ components:
       - type: string
         format: binary
       - type: object
+        required:
+        - success
         properties:
           nillableBool:
             nullable: true

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/returns/Messages.java
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/returns/Messages.java
@@ -11,7 +11,7 @@ import org.codehaus.jackson.map.ObjectMapper;
 @XmlRootElement
 public class Messages {
 	
-	private List<String> messages = new ArrayList<String>();
+	private List<String> messages = new ArrayList<>();
 	
 	public List<String> getMessages() {
 		return messages;
@@ -30,7 +30,7 @@ public class Messages {
 
 	@JsonIgnore
 	public boolean isNotOk() {
-		return messages.stream().anyMatch(m -> "error".equals(m));
+		return messages.stream().anyMatch("error"::equals);
 	}
 
 	@JsonIgnore
@@ -41,7 +41,7 @@ public class Messages {
 	@Override
 	public String toString() {
 		try {
-			return new ObjectMapper().writeValueAsString(this).toString();
+			return new ObjectMapper().writeValueAsString(this);
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/returns/openapi.yml
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/returns/openapi.yml
@@ -293,6 +293,9 @@ components:
     "json_Messages":
       title: "Messages"
       type: object
+      required:
+      - notOk
+      - OK
       properties:
         messages:
           type: array

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/simple/DataXmlDTO.java
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/simple/DataXmlDTO.java
@@ -46,7 +46,7 @@ public class DataXmlDTO {
 
 	@XmlElement(name="success", nillable=false)
 	private boolean success = true;
-	    
+
 	@XmlElement(name="message", nillable=true)
 	private String message;
 

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/simple/openapi.yml
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/simple/openapi.yml
@@ -127,6 +127,8 @@ components:
       - type: string
         format: binary
       - type: object
+        required:
+        - success
         properties:
           first:
             description: "First string. Should be first in serialization order."

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/utf8/openapi.yml
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/utf8/openapi.yml
@@ -37,9 +37,11 @@ components:
       type: object
       properties:
         fieldContainsDanishLettersÆØÅæøå:
-          type: number
+          type: integer
+          format: int32
         noFunkyLettersHere:
-          type: number
+          type: integer
+          format: int32
       example:
         fieldContainsDanishLettersÆØÅæøå: 12345
         noFunkyLettersHere: 12345


### PR DESCRIPTION
Hi, 
For some reason 2.11.1 doesn't work for me. But 2.12.0 Enunciate works. So this update in highly appreciated. Jackson finally newer which brings some DateTime api nicer handling.
The implementation in naive as all these are compile time operations.
I double create `DefaultRegistrationContext` for example in `OpenApiModule.java` for example, because new Enunciate changes API a bit and I just avoided compilation errors. Feel free to correct it. Please let's update.
Thank you for the tool!