### PR TITLE
Add flag to exclude examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ You can also use a relative path. In this case, you should know that the base pa
 	  <modules>
 	    <openapi disabled="false" base="../src/main/enunciate/custom-swagger-ui"/>
 
+### Removing 'json_' prefix ###
+Enunciate generates output with the prefix 'json_'. To prevent this prefix from showing up in the OpenAPI service definition (openapi.yml), you
+can add the flag 'removeObjectPrefix'. The default value is 'false'.
+
+     <enunciate>
+	  <modules>
+	    <openapi disabled="false" removeObjectPrefix="true"/>
+
+### Excluding examples ###
+Enunciate provides the option to include examples of the request/response body, but if you use an Enum in it, the Enum value
+is chosen randomly. This can be inconvenient when you are developing because the output will always be different and this makes it hard to spot the changes that you are working on. 
+To alleviate this problem you can exclude the examples by setting the flag 'disableExamples=true' on the openapi element in enunciate.xml. The default value is 'false'.
+
+     <enunciate>
+	  <modules>
+	    <openapi disabled="false" disableExamples="true"/>
 
 ## Release ##
 

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/ObjectTypeRenderer.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/ObjectTypeRenderer.java
@@ -59,12 +59,14 @@ public class ObjectTypeRenderer {
     private final Set<String> passThroughAnnotations;
 
     private final boolean removeObjectPrefix;
+    private final boolean excludeExamples;
 
-    public ObjectTypeRenderer(EnunciateLogger enunciateLogger, DataTypeReferenceRenderer datatypeRefRenderer, Set<String> passThroughAnnotations, boolean removeObjectPrefix) {
+    public ObjectTypeRenderer(EnunciateLogger enunciateLogger, DataTypeReferenceRenderer datatypeRefRenderer, Set<String> passThroughAnnotations, boolean removeObjectPrefix, boolean excludeExamples) {
         this.logger = enunciateLogger;
         this.datatypeRefRenderer = datatypeRefRenderer;
         this.passThroughAnnotations = passThroughAnnotations;
         this.removeObjectPrefix = removeObjectPrefix;
+        this.excludeExamples = excludeExamples;
     }
 
     public void render(IndententationPrinter ip, DataType datatype, boolean syntaxIsJson) {
@@ -98,7 +100,9 @@ public class ObjectTypeRenderer {
         addOptionalEnum(ip, datatype);
         addOptionalXml(ip, datatype);
 
-        addOptionalExample(ip, datatype, syntaxIsJson);
+        if ( !excludeExamples) {
+            addOptionalExample(ip, datatype, syntaxIsJson);
+        }
     }
 
     private void addOptionalSupertypeHeader(IndententationPrinter ip, DataType datatype) {

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/ObjectTypeRenderer.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/ObjectTypeRenderer.java
@@ -59,14 +59,14 @@ public class ObjectTypeRenderer {
     private final Set<String> passThroughAnnotations;
 
     private final boolean removeObjectPrefix;
-    private final boolean excludeExamples;
+    private final boolean disableExamples;
 
-    public ObjectTypeRenderer(EnunciateLogger enunciateLogger, DataTypeReferenceRenderer datatypeRefRenderer, Set<String> passThroughAnnotations, boolean removeObjectPrefix, boolean excludeExamples) {
+    public ObjectTypeRenderer(EnunciateLogger enunciateLogger, DataTypeReferenceRenderer datatypeRefRenderer, Set<String> passThroughAnnotations, boolean removeObjectPrefix, boolean disableExamples) {
         this.logger = enunciateLogger;
         this.datatypeRefRenderer = datatypeRefRenderer;
         this.passThroughAnnotations = passThroughAnnotations;
         this.removeObjectPrefix = removeObjectPrefix;
-        this.excludeExamples = excludeExamples;
+        this.disableExamples = disableExamples;
     }
 
     public void render(IndententationPrinter ip, DataType datatype, boolean syntaxIsJson) {
@@ -100,7 +100,7 @@ public class ObjectTypeRenderer {
         addOptionalEnum(ip, datatype);
         addOptionalXml(ip, datatype);
 
-        if ( !excludeExamples) {
+        if ( !disableExamples) {
             addOptionalExample(ip, datatype, syntaxIsJson);
         }
     }

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/OpenApiModule.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/OpenApiModule.java
@@ -204,7 +204,7 @@ public class OpenApiModule extends BasicGeneratingModule implements ApiFeaturePr
     protected void writeToFolder(File dir) throws IOException {
       EnunciateLogger logger = enunciate.getLogger();
       DataTypeReferenceRenderer dataTypeReferenceRenderer = new DataTypeReferenceRenderer(logger, doRemoveObjectPrefix());
-      ObjectTypeRenderer objectTypeRenderer = new ObjectTypeRenderer(logger, dataTypeReferenceRenderer, getPassThroughAnnotations(), doRemoveObjectPrefix());
+      ObjectTypeRenderer objectTypeRenderer = new ObjectTypeRenderer(logger, dataTypeReferenceRenderer, getPassThroughAnnotations(), doRemoveObjectPrefix(), excludeExamples());
       
       dir.mkdirs();
       Map<String, Object> model = new HashMap<>();
@@ -222,6 +222,10 @@ public class OpenApiModule extends BasicGeneratingModule implements ApiFeaturePr
       catch (TemplateException e) {
         throw new EnunciateException(e);
       }
+    }
+
+    private boolean excludeExamples() {
+      return Boolean.parseBoolean(config.getString("[@excludeExamples]"));
     }
 
 	  /**

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/OpenApiModule.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/OpenApiModule.java
@@ -204,7 +204,7 @@ public class OpenApiModule extends BasicGeneratingModule implements ApiFeaturePr
     protected void writeToFolder(File dir) throws IOException {
       EnunciateLogger logger = enunciate.getLogger();
       DataTypeReferenceRenderer dataTypeReferenceRenderer = new DataTypeReferenceRenderer(logger, doRemoveObjectPrefix());
-      ObjectTypeRenderer objectTypeRenderer = new ObjectTypeRenderer(logger, dataTypeReferenceRenderer, getPassThroughAnnotations(), doRemoveObjectPrefix(), excludeExamples());
+      ObjectTypeRenderer objectTypeRenderer = new ObjectTypeRenderer(logger, dataTypeReferenceRenderer, getPassThroughAnnotations(), doRemoveObjectPrefix(), disableExamples());
       
       dir.mkdirs();
       Map<String, Object> model = new HashMap<>();
@@ -224,8 +224,8 @@ public class OpenApiModule extends BasicGeneratingModule implements ApiFeaturePr
       }
     }
 
-    private boolean excludeExamples() {
-      return Boolean.parseBoolean(config.getString("[@excludeExamples]"));
+    private boolean disableExamples() {
+      return Boolean.parseBoolean(config.getString("[@disableExamples]"));
     }
 
 	  /**

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/ObjectTypeRendererTest.java
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/ObjectTypeRendererTest.java
@@ -24,7 +24,7 @@ class ObjectTypeRendererTest {
     void verifyRenderAbstractType() {
 
         ObjectTypeRenderer objectTypeRenderer = new ObjectTypeRenderer(new OutputLogger(), null
-                , null, false);
+                , null, false, false);
 
         IndententationPrinter ip = getIndentationPrinter();
         DataType abstractType = getAbstractTypeWithTwoSubtypes();
@@ -39,7 +39,7 @@ class ObjectTypeRendererTest {
     @Test
     void verifyRenderConcreteType() {
         ObjectTypeRenderer objectTypeRenderer = new ObjectTypeRenderer(new OutputLogger(), null
-                , null, false);
+                , null, false, false);
 
         IndententationPrinter ip = getIndentationPrinter();
         DataType concreteType = getConcreteType();


### PR DESCRIPTION
Examples are included by default for backward compatibility, but the option is added to exclude them.

This flag can be added to the Enunciate config file, like so:
 <openapi excludeExamples="true" ...

If this new attribute is omitted, then the examples are still generated in the output YAML file.