### PR TITLE
Add support for multi dim arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ You can also use a relative path. In this case, you should know that the base pa
 	  <modules>
 	    <openapi disabled="false" base="../src/main/enunciate/custom-swagger-ui"/>
 
+### Removing 'json_' prefix ###
+Enunciate generates output with the prefix 'json_'. To prevent this prefix from showing up in the OpenAPI service definition (openapi.yml), you
+can add the flag 'removeObjectPrefix'. The default value is 'false'.
+
+     <enunciate>
+	  <modules>
+	    <openapi disabled="false" removeObjectPrefix="true"/>
+
+### Excluding examples ###
+Enunciate provides the option to include examples of the request/response body, but if you use an Enum in it, the Enum value
+is chosen randomly. This can be inconvenient when you are developing because the output will always be different and this makes it hard to spot the changes that you are working on. 
+To alleviate this problem you can exclude the examples by setting the flag 'disableExamples=true' on the openapi element in enunciate.xml. The default value is 'false'.
+
+     <enunciate>
+	  <modules>
+	    <openapi disabled="false" disableExamples="true"/>
 
 ## Release ##
 

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/DataTypeReferenceRenderer.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/DataTypeReferenceRenderer.java
@@ -64,7 +64,7 @@ public class DataTypeReferenceRenderer {
             }
         } else {
             if (hasContainers) {
-                if (containers.stream().noneMatch(c -> c.isMap())) {
+                if (isMultiDimensionalCollection(containers)) {
                     renderNestedArrays(ip, dtr, containers);
 
                 } else {
@@ -94,6 +94,10 @@ public class DataTypeReferenceRenderer {
                 }
             }
         }
+    }
+
+    private boolean isMultiDimensionalCollection(List<ContainerType> containers) {
+        return containers.stream().noneMatch(c -> c.isMap());
     }
 
     private void renderNestedArrays(IndententationPrinter ip, DataTypeReference dtr, List<ContainerType> containers) {

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/DataTypeReferenceRenderer.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/DataTypeReferenceRenderer.java
@@ -23,7 +23,7 @@ import com.webcohesion.enunciate.api.resources.Parameter;
 import com.webcohesion.enunciate.modules.jaxb.api.impl.DataTypeReferenceImpl;
 import com.webcohesion.enunciate.modules.jaxb.model.types.MapXmlType;
 import com.webcohesion.enunciate.modules.jaxb.model.types.XmlType;
-import dk.jyskebank.tools.enunciate.modules.openapi.yaml.IndententationPrinter;
+import dk.jyskebank.tools.enunciate.modules.openapi.yaml.IndentationPrinter;
 import dk.jyskebank.tools.enunciate.modules.openapi.yaml.YamlHelper;
 
 import java.util.List;
@@ -37,7 +37,7 @@ public class DataTypeReferenceRenderer {
         this.removeObjectPrefix = removeObjectPrefix;
     }
 
-    public void render(IndententationPrinter ip, DataTypeReference dtr, String description) {
+    public void render(IndentationPrinter ip, DataTypeReference dtr, String description) {
         if (dtr == null) {
             throw new IllegalStateException("Cannot render null data type");
         }
@@ -99,7 +99,7 @@ public class DataTypeReferenceRenderer {
         return containers.stream().noneMatch(c -> c.isMap());
     }
 
-    private void renderNestedArrays(IndententationPrinter ip, DataTypeReference dtr, int dimensionSize) {
+    private void renderNestedArrays(IndentationPrinter ip, DataTypeReference dtr, int dimensionSize) {
 
         if (dimensionSize == 0) {
             renderValue(ip, () -> renderType(ip, dtr));
@@ -111,11 +111,11 @@ public class DataTypeReferenceRenderer {
         }
     }
 
-    private void renderValue(IndententationPrinter ip, Runnable valueTypeRenderer) {
+    private void renderValue(IndentationPrinter ip, Runnable valueTypeRenderer) {
         valueTypeRenderer.run(); // NOSONAR
     }
 
-    private void renderContainer(IndententationPrinter ip, boolean isMap, Runnable valueTypeRenderer) {
+    private void renderContainer(IndentationPrinter ip, boolean isMap, Runnable valueTypeRenderer) {
         if (isMap) {
             renderMapContainer(ip, valueTypeRenderer);
         } else {
@@ -123,19 +123,19 @@ public class DataTypeReferenceRenderer {
         }
     }
 
-    private void renderNonMapContainer(IndententationPrinter ip, Runnable valueTypeRenderer) {
+    private void renderNonMapContainer(IndentationPrinter ip, Runnable valueTypeRenderer) {
         renderArray(ip);
         ip.nextLevel();
         renderValue(ip, valueTypeRenderer);
         ip.prevLevel();
     }
 
-    private void renderArray(IndententationPrinter ip) {
+    private void renderArray(IndentationPrinter ip) {
         ip.add("type: array");
         ip.add("items:");
     }
 
-    private void renderMapContainer(IndententationPrinter ip, Runnable valueTypeRenderer) {
+    private void renderMapContainer(IndentationPrinter ip, Runnable valueTypeRenderer) {
         ip.add("type: object");
         ip.add("additionalProperties:");
         ip.nextLevel();
@@ -143,30 +143,30 @@ public class DataTypeReferenceRenderer {
         ip.prevLevel();
     }
 
-    public void renderType(IndententationPrinter ip, Parameter parameter) {
+    public void renderType(IndentationPrinter ip, Parameter parameter) {
         renderType(ip, OpenApiTypeFormat.from(parameter));
     }
 
-    private void renderType(IndententationPrinter ip, DataTypeReference dtr) {
+    private void renderType(IndentationPrinter ip, DataTypeReference dtr) {
         renderType(ip, OpenApiTypeFormat.from(dtr));
     }
 
-    private void renderType(IndententationPrinter ip, OpenApiTypeFormat tf) {
+    private void renderType(IndentationPrinter ip, OpenApiTypeFormat tf) {
         ip.add("type: ", tf.getType());
         tf.getFormat().ifPresent(f -> ip.add("format: ", f));
     }
 
-    public void renderObsoletedFileFormat(IndententationPrinter ip) {
+    public void renderObsoletedFileFormat(IndentationPrinter ip) {
         logger.info("CALLING obsoleted format");
         //new Exception("bad code").printStackTrace();
         renderType(ip, OpenApiTypeFormat.BINARY_STREAM_TYPE);
     }
 
-    private static void addSchemaRef(IndententationPrinter ip, DataType value) {
+    private static void addSchemaRef(IndentationPrinter ip, DataType value) {
         addSchemaSlugReference(ip, value.getSlug());
     }
 
-    public void addSchemaRef(IndententationPrinter ip, DataTypeReference ref) {
+    public void addSchemaRef(IndentationPrinter ip, DataTypeReference ref) {
         logger.info("Looking at ref %s", ref.getBaseType());
 
         String slug = ref.getSlug();
@@ -177,7 +177,7 @@ public class DataTypeReferenceRenderer {
         }
     }
 
-    private static void addSchemaSlugReference(IndententationPrinter ip, String slug) {
+    private static void addSchemaSlugReference(IndentationPrinter ip, String slug) {
         ip.add("$ref: \"#/components/schemas/" + slug + "\"");
     }
 

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/ObjectTypeRenderer.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/ObjectTypeRenderer.java
@@ -49,7 +49,7 @@ import com.webcohesion.enunciate.api.datatype.Value;
 import com.webcohesion.enunciate.javac.javadoc.JavaDoc;
 import com.webcohesion.enunciate.metadata.DocumentationExample;
 
-import dk.jyskebank.tools.enunciate.modules.openapi.yaml.IndententationPrinter;
+import dk.jyskebank.tools.enunciate.modules.openapi.yaml.IndentationPrinter;
 import dk.jyskebank.tools.enunciate.modules.openapi.yaml.JsonToYamlHelper;
 
 public class ObjectTypeRenderer {
@@ -69,7 +69,7 @@ public class ObjectTypeRenderer {
         this.disableExamples = disableExamples;
     }
 
-    public void render(IndententationPrinter ip, DataType datatype, boolean syntaxIsJson) {
+    public void render(IndentationPrinter ip, DataType datatype, boolean syntaxIsJson) {
         logger.info("Rendering type " + datatype.getLabel());
         ip.pushNextLevel();
 
@@ -86,11 +86,11 @@ public class ObjectTypeRenderer {
         ip.popLevel();
     }
 
-    private static void addSchemaSlugReference(IndententationPrinter ip, String slug) {
+    private static void addSchemaSlugReference(IndentationPrinter ip, String slug) {
         ip.add(String.format(JSON_REF_FORMAT, slug));
     }
 
-    private void renderConcreteType(IndententationPrinter ip, DataType datatype, boolean syntaxIsJson) {
+    private void renderConcreteType(IndentationPrinter ip, DataType datatype, boolean syntaxIsJson) {
         ip.add("title: ", safeYamlString(datatype.getLabel()));
         addOptionalSupertypeHeader(ip, datatype);
 
@@ -105,7 +105,7 @@ public class ObjectTypeRenderer {
         }
     }
 
-    private void addOptionalSupertypeHeader(IndententationPrinter ip, DataType datatype) {
+    private void addOptionalSupertypeHeader(IndentationPrinter ip, DataType datatype) {
         List<DataTypeReference> supertypes = datatype.getSupertypes();
         if (supertypes == null || supertypes.isEmpty()) {
             return;
@@ -121,7 +121,7 @@ public class ObjectTypeRenderer {
         ip.itemFollows();
     }
 
-    private void addOptionalRequired(IndententationPrinter ip, DataType datatype) {
+    private void addOptionalRequired(IndentationPrinter ip, DataType datatype) {
         List<? extends Property> properties = datatype.getProperties();
         if (properties == null) {
             return;
@@ -163,7 +163,7 @@ public class ObjectTypeRenderer {
         }
     }
 
-    private void addOptionalEnum(IndententationPrinter ip, DataType datatype) {
+    private void addOptionalEnum(IndentationPrinter ip, DataType datatype) {
         List<? extends Value> values = datatype.getValues();
         if (values == null || values.isEmpty()) {
             return;
@@ -175,7 +175,7 @@ public class ObjectTypeRenderer {
         renderEnum(ip, enums);
     }
 
-    public void renderEnum(IndententationPrinter ip, List<String> values) {
+    public void renderEnum(IndentationPrinter ip, List<String> values) {
         ip.add("enum:");
         ip.nextLevel();
         for (String e : values) {
@@ -184,7 +184,7 @@ public class ObjectTypeRenderer {
         ip.prevLevel();
     }
 
-    private void addOptionalProperties(IndententationPrinter ip, DataType datatype, boolean syntaxIsJson) {
+    private void addOptionalProperties(IndentationPrinter ip, DataType datatype, boolean syntaxIsJson) {
         List<? extends Property> properties = datatype.getProperties();
         if (properties == null || properties.isEmpty()) {
             return;
@@ -198,7 +198,7 @@ public class ObjectTypeRenderer {
         ip.prevLevel();
     }
 
-    private void addProperty(IndententationPrinter ip, DataType datatype, Property p, boolean syntaxIsJson) {
+    private void addProperty(IndentationPrinter ip, DataType datatype, Property p, boolean syntaxIsJson) {
         logger.info(" adding property " + p.getName() + " with annotations " + p.getAnnotations().keySet());
 
         ip.add("\"" + p.getName() + "\"", ":");
@@ -222,7 +222,7 @@ public class ObjectTypeRenderer {
         ip.prevLevel();
     }
 
-    private void addPassThroughAnnotations(IndententationPrinter ip, Property p) {
+    private void addPassThroughAnnotations(IndentationPrinter ip, Property p) {
         List<String> annotations = p.getAnnotations().entrySet().stream()
                 .filter(e -> passThroughAnnotations.contains(e.getKey()))
                 .map(e -> renderAnnotation(e.getKey(), e.getValue().getElementValues()))
@@ -254,7 +254,7 @@ public class ObjectTypeRenderer {
         return sb.toString();
     }
 
-    private static void addConstraints(IndententationPrinter ip, Property p) {
+    private static void addConstraints(IndentationPrinter ip, Property p) {
         List<ContainerType> containers = p.getDataType().getContainers();
         boolean isArray = containers != null && !containers.isEmpty();
 
@@ -293,7 +293,7 @@ public class ObjectTypeRenderer {
         }
     }
 
-    private void addOptionalNullable(IndententationPrinter ip, Property p) {
+    private void addOptionalNullable(IndentationPrinter ip, Property p) {
         getNillable(p).ifPresent(isNullable -> {
             if (!TypeHelper.renderAsSimpleRef(p.getDataType())) {
                 ip.add("nullable: ", isNullable);
@@ -301,7 +301,7 @@ public class ObjectTypeRenderer {
         });
     }
 
-    private void addNamespaceXml(IndententationPrinter ip, Property p) {
+    private void addNamespaceXml(IndentationPrinter ip, Property p) {
         PropertyMetadata metadata = AccessorProperty.getMetadata(p);
         if (metadata == null) {
             return;
@@ -351,7 +351,7 @@ public class ObjectTypeRenderer {
                 .findFirst();
     }
 
-    private void addOptionalXml(IndententationPrinter ip, DataType datatype) {
+    private void addOptionalXml(IndentationPrinter ip, DataType datatype) {
         String xmlName = getNonNullAndNonEmpty(AccessorDataType.getXmlName(datatype));
 
         Namespace namespace = datatype.getNamespace();
@@ -379,7 +379,7 @@ public class ObjectTypeRenderer {
         return str.isEmpty() ? null : str;
     }
 
-    private static void addOptionalExample(IndententationPrinter ip, DataType datatype, boolean syntaxIsJson) {
+    private static void addOptionalExample(IndentationPrinter ip, DataType datatype, boolean syntaxIsJson) {
         if (!syntaxIsJson) {
             return;
         }
@@ -387,7 +387,7 @@ public class ObjectTypeRenderer {
         renderExample(ip, getExampleFromType(datatype, datatype.getBaseType(), Optional.empty()));
     }
 
-    private static void addOptionalPropertyExample(IndententationPrinter ip, Property property, boolean syntaxIsJson) {
+    private static void addOptionalPropertyExample(IndentationPrinter ip, Property property, boolean syntaxIsJson) {
         if (!syntaxIsJson) {
             return;
         }
@@ -397,7 +397,7 @@ public class ObjectTypeRenderer {
         renderExample(ip, getExampleFromType(null, baseType, specifiedExample));
     }
 
-    private static void renderExample(IndententationPrinter ip, Optional<String> optExample) {
+    private static void renderExample(IndentationPrinter ip, Optional<String> optExample) {
         optExample.ifPresent(example -> {
             ip.add("example:");
             ip.pushNextLevel();

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/ObjectTypeRenderer.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/ObjectTypeRenderer.java
@@ -59,12 +59,14 @@ public class ObjectTypeRenderer {
     private final Set<String> passThroughAnnotations;
 
     private final boolean removeObjectPrefix;
+    private final boolean excludeExamples;
 
-    public ObjectTypeRenderer(EnunciateLogger enunciateLogger, DataTypeReferenceRenderer datatypeRefRenderer, Set<String> passThroughAnnotations, boolean removeObjectPrefix) {
+    public ObjectTypeRenderer(EnunciateLogger enunciateLogger, DataTypeReferenceRenderer datatypeRefRenderer, Set<String> passThroughAnnotations, boolean removeObjectPrefix, boolean excludeExamples) {
         this.logger = enunciateLogger;
         this.datatypeRefRenderer = datatypeRefRenderer;
         this.passThroughAnnotations = passThroughAnnotations;
         this.removeObjectPrefix = removeObjectPrefix;
+        this.excludeExamples = excludeExamples;
     }
 
     public void render(IndententationPrinter ip, DataType datatype, boolean syntaxIsJson) {
@@ -98,7 +100,9 @@ public class ObjectTypeRenderer {
         addOptionalEnum(ip, datatype);
         addOptionalXml(ip, datatype);
 
-        addOptionalExample(ip, datatype, syntaxIsJson);
+        if ( !excludeExamples) {
+            addOptionalExample(ip, datatype, syntaxIsJson);
+        }
     }
 
     private void addOptionalSupertypeHeader(IndententationPrinter ip, DataType datatype) {

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/ObjectTypeRenderer.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/ObjectTypeRenderer.java
@@ -59,14 +59,14 @@ public class ObjectTypeRenderer {
     private final Set<String> passThroughAnnotations;
 
     private final boolean removeObjectPrefix;
-    private final boolean excludeExamples;
+    private final boolean disableExamples;
 
-    public ObjectTypeRenderer(EnunciateLogger enunciateLogger, DataTypeReferenceRenderer datatypeRefRenderer, Set<String> passThroughAnnotations, boolean removeObjectPrefix, boolean excludeExamples) {
+    public ObjectTypeRenderer(EnunciateLogger enunciateLogger, DataTypeReferenceRenderer datatypeRefRenderer, Set<String> passThroughAnnotations, boolean removeObjectPrefix, boolean disableExamples) {
         this.logger = enunciateLogger;
         this.datatypeRefRenderer = datatypeRefRenderer;
         this.passThroughAnnotations = passThroughAnnotations;
         this.removeObjectPrefix = removeObjectPrefix;
-        this.excludeExamples = excludeExamples;
+        this.disableExamples = disableExamples;
     }
 
     public void render(IndententationPrinter ip, DataType datatype, boolean syntaxIsJson) {
@@ -100,7 +100,7 @@ public class ObjectTypeRenderer {
         addOptionalEnum(ip, datatype);
         addOptionalXml(ip, datatype);
 
-        if ( !excludeExamples) {
+        if ( !disableExamples) {
             addOptionalExample(ip, datatype, syntaxIsJson);
         }
     }

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/OpenApiModule.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/OpenApiModule.java
@@ -204,7 +204,7 @@ public class OpenApiModule extends BasicGeneratingModule implements ApiFeaturePr
     protected void writeToFolder(File dir) throws IOException {
       EnunciateLogger logger = enunciate.getLogger();
       DataTypeReferenceRenderer dataTypeReferenceRenderer = new DataTypeReferenceRenderer(logger, doRemoveObjectPrefix());
-      ObjectTypeRenderer objectTypeRenderer = new ObjectTypeRenderer(logger, dataTypeReferenceRenderer, getPassThroughAnnotations(), doRemoveObjectPrefix());
+      ObjectTypeRenderer objectTypeRenderer = new ObjectTypeRenderer(logger, dataTypeReferenceRenderer, getPassThroughAnnotations(), doRemoveObjectPrefix(), excludeExamples());
       
       dir.mkdirs();
       Map<String, Object> model = new HashMap<>();
@@ -222,6 +222,10 @@ public class OpenApiModule extends BasicGeneratingModule implements ApiFeaturePr
       catch (TemplateException e) {
         throw new EnunciateException(e);
       }
+    }
+
+    private boolean excludeExamples() {
+      return Boolean.parseBoolean(config.getString("[@excludeExamples]"));
     }
 
 	  /**

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/OpenApiModule.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/OpenApiModule.java
@@ -204,7 +204,7 @@ public class OpenApiModule extends BasicGeneratingModule implements ApiFeaturePr
     protected void writeToFolder(File dir) throws IOException {
       EnunciateLogger logger = enunciate.getLogger();
       DataTypeReferenceRenderer dataTypeReferenceRenderer = new DataTypeReferenceRenderer(logger, doRemoveObjectPrefix());
-      ObjectTypeRenderer objectTypeRenderer = new ObjectTypeRenderer(logger, dataTypeReferenceRenderer, getPassThroughAnnotations(), doRemoveObjectPrefix(), excludeExamples());
+      ObjectTypeRenderer objectTypeRenderer = new ObjectTypeRenderer(logger, dataTypeReferenceRenderer, getPassThroughAnnotations(), doRemoveObjectPrefix(), disableExamples());
       
       dir.mkdirs();
       Map<String, Object> model = new HashMap<>();
@@ -224,8 +224,8 @@ public class OpenApiModule extends BasicGeneratingModule implements ApiFeaturePr
       }
     }
 
-    private boolean excludeExamples() {
-      return Boolean.parseBoolean(config.getString("[@excludeExamples]"));
+    private boolean disableExamples() {
+      return Boolean.parseBoolean(config.getString("[@disableExamples]"));
     }
 
 	  /**

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/components/SchemaRenderer.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/components/SchemaRenderer.java
@@ -24,7 +24,7 @@ import com.webcohesion.enunciate.api.datatype.DataType;
 
 import dk.jyskebank.tools.enunciate.modules.freemarker.Typed1ArgTemplateMethod;
 import dk.jyskebank.tools.enunciate.modules.openapi.ObjectTypeRenderer;
-import dk.jyskebank.tools.enunciate.modules.openapi.yaml.IndententationPrinter;
+import dk.jyskebank.tools.enunciate.modules.openapi.yaml.IndentationPrinter;
 
 public class SchemaRenderer extends Typed1ArgTemplateMethod<String, String> {
   private static final Pattern VALID_REF_ID_PATTERN = Pattern.compile("^[a-zA-Z0-9\\.\\-_]+$");
@@ -45,12 +45,12 @@ public class SchemaRenderer extends Typed1ArgTemplateMethod<String, String> {
 
   @Override
   protected String exec(String nextLineIndent) {
-    IndententationPrinter ip = new IndententationPrinter(nextLineIndent, objectTypeRenderer.doRemoveObjectPrefix());
+    IndentationPrinter ip = new IndentationPrinter(nextLineIndent, objectTypeRenderer.doRemoveObjectPrefix());
     renderLines(ip);
     return ip.toString();
   }
   
-  private void renderLines(IndententationPrinter ip) {
+  private void renderLines(IndentationPrinter ip) {
     ip.add(getRefId() + ":");
     objectTypeRenderer.render(ip, datatype, syntaxIsJson);
   }

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/paths/ExampleRenderer.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/paths/ExampleRenderer.java
@@ -21,7 +21,7 @@ import com.webcohesion.enunciate.EnunciateLogger;
 import com.webcohesion.enunciate.api.datatype.Example;
 
 import dk.jyskebank.tools.enunciate.modules.freemarker.Typed1ArgTemplateMethod;
-import dk.jyskebank.tools.enunciate.modules.openapi.yaml.IndententationPrinter;
+import dk.jyskebank.tools.enunciate.modules.openapi.yaml.IndentationPrinter;
 import dk.jyskebank.tools.enunciate.modules.openapi.yaml.JsonToYamlHelper;
 import dk.jyskebank.tools.enunciate.modules.openapi.yaml.YamlHelper;
 
@@ -40,7 +40,7 @@ public class ExampleRenderer extends Typed1ArgTemplateMethod<String, String> {
 
     @Override
     protected String exec(String nextLineIndent) {
-        IndententationPrinter ip = new IndententationPrinter(nextLineIndent, removeObjectPrefix);
+        IndentationPrinter ip = new IndentationPrinter(nextLineIndent, removeObjectPrefix);
 
         if ("js".equals(example.getLang())) {
             String yaml = JsonToYamlHelper.jsonToYaml(example.getBody());

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/paths/ParameterRenderer.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/paths/ParameterRenderer.java
@@ -24,7 +24,7 @@ import com.webcohesion.enunciate.api.resources.Parameter;
 import dk.jyskebank.tools.enunciate.modules.freemarker.Typed1ArgTemplateMethod;
 import dk.jyskebank.tools.enunciate.modules.openapi.DataTypeReferenceRenderer;
 import dk.jyskebank.tools.enunciate.modules.openapi.ObjectTypeRenderer;
-import dk.jyskebank.tools.enunciate.modules.openapi.yaml.IndententationPrinter;
+import dk.jyskebank.tools.enunciate.modules.openapi.yaml.IndentationPrinter;
 
 public class ParameterRenderer extends Typed1ArgTemplateMethod<String, String> {
   @SuppressWarnings("unused") private final EnunciateLogger logger;
@@ -42,7 +42,7 @@ public class ParameterRenderer extends Typed1ArgTemplateMethod<String, String> {
 
   @Override
   protected String exec(String nextLineIndent) {
-    IndententationPrinter ip = new IndententationPrinter(nextLineIndent, dataTypeReferenceRenderer.doRemoveObjectPrefix());
+    IndentationPrinter ip = new IndentationPrinter(nextLineIndent, dataTypeReferenceRenderer.doRemoveObjectPrefix());
 
     addOptionalEnum(ip);
     addType(ip);
@@ -50,7 +50,7 @@ public class ParameterRenderer extends Typed1ArgTemplateMethod<String, String> {
     return ip.toString();
   }
 
-  private void addType(IndententationPrinter ip) {
+  private void addType(IndentationPrinter ip) {
     if (parameter.isMultivalued()) {
       ip.add("type: array");
       ip.add("items:");
@@ -62,7 +62,7 @@ public class ParameterRenderer extends Typed1ArgTemplateMethod<String, String> {
     }
   }
 
-  private void addOptionalEnum(IndententationPrinter ip) {
+  private void addOptionalEnum(IndentationPrinter ip) {
     Set<String> constraintValues = parameter.getConstraintValues();
     if (constraintValues != null && !constraintValues.isEmpty()) {
       objectTypeRenderer.renderEnum(ip, new ArrayList<>(constraintValues));

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/paths/RequestEntityRenderer.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/paths/RequestEntityRenderer.java
@@ -23,7 +23,7 @@ import dk.jyskebank.tools.enunciate.modules.freemarker.Typed1ArgTemplateMethod;
 import dk.jyskebank.tools.enunciate.modules.openapi.DataTypeReferenceRenderer;
 import dk.jyskebank.tools.enunciate.modules.openapi.FindBestDataTypeMethod;
 import dk.jyskebank.tools.enunciate.modules.openapi.FindBestDataTypeMethod.MediaAndType;
-import dk.jyskebank.tools.enunciate.modules.openapi.yaml.IndententationPrinter;
+import dk.jyskebank.tools.enunciate.modules.openapi.yaml.IndentationPrinter;
 
 public class RequestEntityRenderer extends Typed1ArgTemplateMethod<String, String> {
   private MediaAndType mediaAndType;
@@ -42,7 +42,7 @@ public class RequestEntityRenderer extends Typed1ArgTemplateMethod<String, Strin
   
   @Override
   protected String exec(String nextLineIndent) {
-      IndententationPrinter ip = new IndententationPrinter(nextLineIndent, dataTypeReferenceRenderer.doRemoveObjectPrefix());
+      IndentationPrinter ip = new IndentationPrinter(nextLineIndent, dataTypeReferenceRenderer.doRemoveObjectPrefix());
 
       ip.add(safeYamlString(mediaWithFallback), ":");
       ip.nextLevel();

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/paths/ResponseDataTypeRenderer.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/paths/ResponseDataTypeRenderer.java
@@ -20,7 +20,7 @@ import com.webcohesion.enunciate.api.datatype.DataTypeReference;
 
 import dk.jyskebank.tools.enunciate.modules.freemarker.Typed1ArgTemplateMethod;
 import dk.jyskebank.tools.enunciate.modules.openapi.DataTypeReferenceRenderer;
-import dk.jyskebank.tools.enunciate.modules.openapi.yaml.IndententationPrinter;
+import dk.jyskebank.tools.enunciate.modules.openapi.yaml.IndentationPrinter;
 
 public class ResponseDataTypeRenderer extends Typed1ArgTemplateMethod<String, String> {
   @SuppressWarnings("unused") private final EnunciateLogger logger;
@@ -38,7 +38,7 @@ public class ResponseDataTypeRenderer extends Typed1ArgTemplateMethod<String, St
 
   @Override
   protected String exec(String nextLineIndent) {
-    IndententationPrinter ip = new IndententationPrinter(nextLineIndent, dataTypeReferenceRenderer.doRemoveObjectPrefix());
+    IndentationPrinter ip = new IndentationPrinter(nextLineIndent, dataTypeReferenceRenderer.doRemoveObjectPrefix());
 
     dataTypeReferenceRenderer.render(ip, dataType, description);
     return ip.toString();

--- a/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/yaml/IndentationPrinter.java
+++ b/src/main/java/dk/jyskebank/tools/enunciate/modules/openapi/yaml/IndentationPrinter.java
@@ -23,7 +23,7 @@ import java.util.Deque;
 /**
  * Printer helping keep track of YAML indentation levels.
  */
-public class IndententationPrinter {
+public class IndentationPrinter {
     private static final String DOS_NEWLINE = "\r\n";
     private static final String SEQUENCE_PREFIX = "- ";
     public static final String JSON_ = "json_";
@@ -33,7 +33,7 @@ public class IndententationPrinter {
     private boolean itemFollows;
     private boolean removeObjectPrefix;
 
-    public IndententationPrinter(String initialIndentation, boolean removeObjectPrefix) {
+    public IndentationPrinter(String initialIndentation, boolean removeObjectPrefix) {
         this.removeObjectPrefix = removeObjectPrefix;
         indentLevelStack.push(new IndentLevel(initialIndentation));
     }
@@ -46,12 +46,12 @@ public class IndententationPrinter {
         this.itemFollows = true;
     }
 
-    public IndententationPrinter item(String... lines) {
+    public IndentationPrinter item(String... lines) {
         itemFollows = true;
         return add(lines);
     }
 
-    public IndententationPrinter add(String... lines) {
+    public IndentationPrinter add(String... lines) {
         addIndentationForAllButFirstLine();
         for (String line : lines) {
             if (removeObjectPrefix) {
@@ -78,12 +78,12 @@ public class IndententationPrinter {
         }
     }
 
-    public IndententationPrinter nextLevel() {
+    public IndentationPrinter nextLevel() {
         indentLevelStack.push(getActive().next());
         return this;
     }
 
-    public IndententationPrinter prevLevel() {
+    public IndentationPrinter prevLevel() {
         if (indentLevelStack.size() == 1) {
             throw new IllegalStateException("Cannot go beyond initial indentation");
         }
@@ -91,12 +91,12 @@ public class IndententationPrinter {
         return this;
     }
 
-    public IndententationPrinter pushNextLevel() {
+    public IndentationPrinter pushNextLevel() {
         memoryStack.push(getActive());
         return nextLevel();
     }
 
-    public IndententationPrinter popLevel() {
+    public IndentationPrinter popLevel() {
         IndentLevel revertTo = memoryStack.pop();
         while (indentLevelStack.peek() != revertTo) {
             indentLevelStack.pop();

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/DataTypeReferenceRendererTest.java
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/DataTypeReferenceRendererTest.java
@@ -1,0 +1,110 @@
+package dk.jyskebank.tools.enunciate.modules.openapi;
+
+import com.webcohesion.enunciate.api.datatype.BaseType;
+import com.webcohesion.enunciate.api.datatype.BaseTypeFormat;
+import com.webcohesion.enunciate.api.datatype.DataTypeReference;
+import dk.jyskebank.tools.enunciate.modules.openapi.yaml.IndententationPrinter;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DataTypeReferenceRendererTest {
+
+    private static final String DOS_NEWLINE = "\r\n";
+
+    @Test
+    void verifyRenderingOfOneDimensionalArray() {
+
+
+        DataTypeReferenceRenderer renderer = new DataTypeReferenceRenderer(new OutputLogger(), false);
+
+        DataTypeReference dtr = mock(DataTypeReference.class);
+        List<DataTypeReference.ContainerType> containers = new ArrayList<>();
+        containers.add(DataTypeReference.ContainerType.array);
+        when(dtr.getContainers()).thenReturn(containers);
+        when(dtr.getBaseType()).thenReturn(BaseType.number);
+        when(dtr.getBaseTypeFormat()).thenReturn(BaseTypeFormat.INT32);
+        final IndententationPrinter ip = TestHelper.getIndentationPrinter();
+        renderer.render(ip, dtr, null);
+
+        final String expected = createExpectedResultOneDimensionalArray();
+        assertEquals(expected, ip.toString());
+    }
+
+    @Test
+    void verifyRenderingOfTwoDimensionalArray() {
+
+        DataTypeReferenceRenderer renderer = new DataTypeReferenceRenderer(new OutputLogger(), false);
+
+        DataTypeReference dtr = mock(DataTypeReference.class);
+        List<DataTypeReference.ContainerType> containers = new ArrayList<>();
+        containers.add(DataTypeReference.ContainerType.array);
+        containers.add(DataTypeReference.ContainerType.array);
+        when(dtr.getContainers()).thenReturn(containers);
+        when(dtr.getBaseType()).thenReturn(BaseType.number);
+        when(dtr.getBaseTypeFormat()).thenReturn(BaseTypeFormat.INT32);
+
+        final IndententationPrinter ip = TestHelper.getIndentationPrinter();
+        renderer.render(ip, dtr, null);
+
+        final String expected = createExpectedResultTwoDimensionalArray();
+        assertEquals(expected, ip.toString());
+    }
+
+    @Test
+    void verifyRenderingOfThreeDimensionalArray() {
+
+        DataTypeReferenceRenderer renderer = new DataTypeReferenceRenderer(new OutputLogger(), false);
+
+        DataTypeReference dtr = mock(DataTypeReference.class);
+        List<DataTypeReference.ContainerType> containers = new ArrayList<>();
+        containers.add(DataTypeReference.ContainerType.array);
+        containers.add(DataTypeReference.ContainerType.array);
+        containers.add(DataTypeReference.ContainerType.array);
+        when(dtr.getContainers()).thenReturn(containers);
+        when(dtr.getBaseType()).thenReturn(BaseType.number);
+        when(dtr.getBaseTypeFormat()).thenReturn(BaseTypeFormat.INT32);
+
+        final IndententationPrinter ip = TestHelper.getIndentationPrinter();
+        renderer.render(ip, dtr, null);
+
+        final String expected = createExpectedResultThreeDimensionalArray();
+        assertEquals(expected, ip.toString());
+    }
+
+    private String createExpectedResultOneDimensionalArray() {
+        return "type: array" + DOS_NEWLINE +
+                "items:" + DOS_NEWLINE +
+                TestHelper.INITIAL_INDENTATION + "  type: integer" + DOS_NEWLINE +
+                TestHelper.INITIAL_INDENTATION + "  format: int32";
+
+
+    }
+
+    private String createExpectedResultTwoDimensionalArray() {
+        return "type: array" + DOS_NEWLINE +
+                "items:" + DOS_NEWLINE +
+                TestHelper.INITIAL_INDENTATION + "  type: array" + DOS_NEWLINE +
+                TestHelper.INITIAL_INDENTATION + "  items:" + DOS_NEWLINE +
+                TestHelper.INITIAL_INDENTATION + "    type: integer" + DOS_NEWLINE +
+                TestHelper.INITIAL_INDENTATION + "    format: int32";
+
+
+    }
+
+    private String createExpectedResultThreeDimensionalArray() {
+        return "type: array" + DOS_NEWLINE +
+                "items:" + DOS_NEWLINE +
+                TestHelper.INITIAL_INDENTATION + "  type: array" + DOS_NEWLINE +
+                TestHelper.INITIAL_INDENTATION + "  items:" + DOS_NEWLINE +
+                TestHelper.INITIAL_INDENTATION + "    type: array" + DOS_NEWLINE +
+                TestHelper.INITIAL_INDENTATION + "    items:" + DOS_NEWLINE +
+                TestHelper.INITIAL_INDENTATION + "      type: integer" + DOS_NEWLINE +
+                TestHelper.INITIAL_INDENTATION + "      format: int32";
+    }
+}

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/ObjectTypeRendererTest.java
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/ObjectTypeRendererTest.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.when;
 
 class ObjectTypeRendererTest {
 
-    public static final String INITIAL_INDENTATION = "x";
+
     public static final String CONCRETE_TYPE_LABEL = "ConcreteX";
 
     @Test
@@ -26,7 +26,7 @@ class ObjectTypeRendererTest {
         ObjectTypeRenderer objectTypeRenderer = new ObjectTypeRenderer(new OutputLogger(), null
                 , null, false, false);
 
-        IndententationPrinter ip = getIndentationPrinter();
+        IndententationPrinter ip = TestHelper.getIndentationPrinter();
         DataType abstractType = getAbstractTypeWithTwoSubtypes();
 
         objectTypeRenderer.render(ip, abstractType, true);
@@ -41,7 +41,7 @@ class ObjectTypeRendererTest {
         ObjectTypeRenderer objectTypeRenderer = new ObjectTypeRenderer(new OutputLogger(), null
                 , null, false, false);
 
-        IndententationPrinter ip = getIndentationPrinter();
+        IndententationPrinter ip = TestHelper.getIndentationPrinter();
         DataType concreteType = getConcreteType();
 
         objectTypeRenderer.render(ip, concreteType, false);
@@ -56,7 +56,7 @@ class ObjectTypeRendererTest {
         return String.format("title: \"%s\"%s%s  type: string",
                 CONCRETE_TYPE_LABEL,
                 DOS_NEWLINE,
-                INITIAL_INDENTATION);
+                TestHelper.INITIAL_INDENTATION);
     }
 
     private DataType getConcreteType() {
@@ -77,10 +77,10 @@ class ObjectTypeRendererTest {
         String DOS_NEWLINE = "\r\n";
         return String.format("oneOf: %s%s  %s%s%s  %s",
                 DOS_NEWLINE,
-                INITIAL_INDENTATION,
+                TestHelper.INITIAL_INDENTATION,
                 getJsonRefForSubType("A"),
                 DOS_NEWLINE,
-                INITIAL_INDENTATION,
+                TestHelper.INITIAL_INDENTATION,
                 getJsonRefForSubType("B"));
     }
 
@@ -88,9 +88,7 @@ class ObjectTypeRendererTest {
         return String.format(JSON_REF_FORMAT, a);
     }
 
-    private IndententationPrinter getIndentationPrinter() {
-        return new IndententationPrinter(INITIAL_INDENTATION, false);
-    }
+
 
     private DataType getAbstractTypeWithTwoSubtypes() {
 

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/ObjectTypeRendererTest.java
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/ObjectTypeRendererTest.java
@@ -3,7 +3,7 @@ package dk.jyskebank.tools.enunciate.modules.openapi;
 import com.webcohesion.enunciate.api.datatype.BaseType;
 import com.webcohesion.enunciate.api.datatype.DataType;
 import com.webcohesion.enunciate.api.datatype.DataTypeReference;
-import dk.jyskebank.tools.enunciate.modules.openapi.yaml.IndententationPrinter;
+import dk.jyskebank.tools.enunciate.modules.openapi.yaml.IndentationPrinter;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -26,7 +26,7 @@ class ObjectTypeRendererTest {
         ObjectTypeRenderer objectTypeRenderer = new ObjectTypeRenderer(new OutputLogger(), null
                 , null, false, false);
 
-        IndententationPrinter ip = TestHelper.getIndentationPrinter();
+        IndentationPrinter ip = TestHelper.getIndentationPrinter();
         DataType abstractType = getAbstractTypeWithTwoSubtypes();
 
         objectTypeRenderer.render(ip, abstractType, true);
@@ -41,7 +41,7 @@ class ObjectTypeRendererTest {
         ObjectTypeRenderer objectTypeRenderer = new ObjectTypeRenderer(new OutputLogger(), null
                 , null, false, false);
 
-        IndententationPrinter ip = TestHelper.getIndentationPrinter();
+        IndentationPrinter ip = TestHelper.getIndentationPrinter();
         DataType concreteType = getConcreteType();
 
         objectTypeRenderer.render(ip, concreteType, false);

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/ObjectTypeRendererTest.java
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/ObjectTypeRendererTest.java
@@ -24,7 +24,7 @@ class ObjectTypeRendererTest {
     void verifyRenderAbstractType() {
 
         ObjectTypeRenderer objectTypeRenderer = new ObjectTypeRenderer(new OutputLogger(), null
-                , null, false);
+                , null, false, false);
 
         IndententationPrinter ip = getIndentationPrinter();
         DataType abstractType = getAbstractTypeWithTwoSubtypes();
@@ -39,7 +39,7 @@ class ObjectTypeRendererTest {
     @Test
     void verifyRenderConcreteType() {
         ObjectTypeRenderer objectTypeRenderer = new ObjectTypeRenderer(new OutputLogger(), null
-                , null, false);
+                , null, false, false);
 
         IndententationPrinter ip = getIndentationPrinter();
         DataType concreteType = getConcreteType();

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/TestHelper.java
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/TestHelper.java
@@ -1,13 +1,13 @@
 package dk.jyskebank.tools.enunciate.modules.openapi;
 
-import dk.jyskebank.tools.enunciate.modules.openapi.yaml.IndententationPrinter;
+import dk.jyskebank.tools.enunciate.modules.openapi.yaml.IndentationPrinter;
 
 public class TestHelper {
 
 
     public static final String INITIAL_INDENTATION = "";
 
-    public static IndententationPrinter getIndentationPrinter() {
-        return new IndententationPrinter(INITIAL_INDENTATION, false);
+    public static IndentationPrinter getIndentationPrinter() {
+        return new IndentationPrinter(INITIAL_INDENTATION, false);
     }
 }

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/TestHelper.java
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/TestHelper.java
@@ -1,0 +1,13 @@
+package dk.jyskebank.tools.enunciate.modules.openapi;
+
+import dk.jyskebank.tools.enunciate.modules.openapi.yaml.IndententationPrinter;
+
+public class TestHelper {
+
+
+    public static final String INITIAL_INDENTATION = "";
+
+    public static IndententationPrinter getIndentationPrinter() {
+        return new IndententationPrinter(INITIAL_INDENTATION, false);
+    }
+}

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/multi_dim_array/DataDTO.java
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/multi_dim_array/DataDTO.java
@@ -1,15 +1,14 @@
 package dk.jyskebank.tools.enunciate.modules.openapi.multi_dim_array;
 
 import com.fasterxml.jackson.annotation.JsonRootName;
-import com.webcohesion.enunciate.metadata.rs.TypeHint;
-
-import java.util.List;
 
 @JsonRootName("multiDimArraySupport")
 public class DataDTO {
     private String name;
 
-    private List<int[]> temperatures;
+    private int[][][] temperatures;
+
+    private int[][] sudoku;
 
     private int[] locations;
 
@@ -21,12 +20,11 @@ public class DataDTO {
         this.name = name;
     }
 
-    @TypeHint(int[][].class)
-    public List<int[]> getTemperatures() {
+    public int[][][] getTemperatures() {
         return temperatures;
     }
 
-    public void setTemperatures(List<int[]> temperatures) {
+    public void setTemperatures(int[][][] temperatures) {
         this.temperatures = temperatures;
     }
 
@@ -36,5 +34,9 @@ public class DataDTO {
 
     public void setLocations(int[] locations) {
         this.locations = locations;
+    }
+
+    public int[][] getSudoku() {
+        return sudoku;
     }
 }

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/multi_dim_array/DataDTO.java
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/multi_dim_array/DataDTO.java
@@ -1,0 +1,40 @@
+package dk.jyskebank.tools.enunciate.modules.openapi.multi_dim_array;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+import com.webcohesion.enunciate.metadata.rs.TypeHint;
+
+import java.util.List;
+
+@JsonRootName("multiDimArraySupport")
+public class DataDTO {
+    private String name;
+
+    private List<int[]> temperatures;
+
+    private int[] locations;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @TypeHint(int[][].class)
+    public List<int[]> getTemperatures() {
+        return temperatures;
+    }
+
+    public void setTemperatures(List<int[]> temperatures) {
+        this.temperatures = temperatures;
+    }
+
+    public int[] getLocations() {
+        return locations;
+    }
+
+    public void setLocations(int[] locations) {
+        this.locations = locations;
+    }
+}

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/multi_dim_array/DataResource.java
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/multi_dim_array/DataResource.java
@@ -1,0 +1,47 @@
+package dk.jyskebank.tools.enunciate.modules.openapi.multi_dim_array;
+
+import com.webcohesion.enunciate.metadata.rs.*;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+
+@ResourceGroup("Data")
+@RequestHeaders({ // Common headers
+	@RequestHeader(name = "userid", description = "The actual user performing the operation") 
+})
+@StatusCodes({ // Common response codes
+	@ResponseCode(code = 400, condition = "Bad request, inspect response payload for error details"),
+	@ResponseCode(code = 401, condition = "Unauthorized, please provide valid Authentication header"),
+	@ResponseCode(code = 403, condition = "Forbidden, user does not have permission"),
+	@ResponseCode(code = 404, condition = "Not Found, inspect response for more info"),
+	@ResponseCode(code = 500, condition = "Internal Server Error, Unexpected server error")
+})
+
+@Path("/data/{pathArg}")
+public class DataResource {
+
+	/**
+	 * Summary.
+	 *
+	 * Description follows...
+	 *
+	 * @param pathArg
+	 *            The id of the customer
+	 */
+	@StatusCodes({
+			@ResponseCode(code = 201, condition = "Created, Consents created", type=@TypeHint(DataDTO.class)),
+			@ResponseCode(code = 204, condition = "No Content, Current consents updated")
+	})
+
+	@POST
+	@Produces(MediaType.APPLICATION_JSON)
+	@Consumes(MediaType.APPLICATION_JSON)
+	public Response update(@PathParam("pathArg") String pathArg, @NotNull(message = "Mandatory consents payload is missing") @Valid DataDTO customerDTO) {
+		return Response.ok(new DataDTO()).build();
+	}
+
+}

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/multi_dim_array/enunciate.xml
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/multi_dim_array/enunciate.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<enunciate version="version from enunciate.xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://enunciate.webcohesion.com/schemas/enunciate-2.11.1.xsd">
+	<title>Title from enunciate.xml</title>
+	<description>Description from enunciate.xml. Can contain weird letters æøåÆØÅ</description>
+
+	<modules disabledByDefault="true">
+		<openapi disabled="false" skipBase="false" />
+		<jaxrs groupBy="annotation" disabled="false" />
+		<jackson disabled="false" />
+		<jaxb disabled="false" />
+		<jaxrs disabled="false" />
+	</modules>
+</enunciate>

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/multi_dim_array/openapi.yml
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/multi_dim_array/openapi.yml
@@ -74,20 +74,38 @@ components:
           items:
             type: array
             items:
-              type: integer
-              format: int32
+              type: array
+              items:
+                type: integer
+                format: int32
         "locations":
           type: array
           items:
             type: integer
             format: int32
+        "sudoku":
+          type: array
+          items:
+            type: array
+            items:
+              type: integer
+              format: int32
       example:
         name: "..."
         temperatures:
-        - - 12345
-          - 12345
-        - - 12345
-          - 12345
+        - - - 12345
+            - 12345
+          - - 12345
+            - 12345
+        - - - 12345
+            - 12345
+          - - 12345
+            - 12345
         locations:
         - 12345
         - 12345
+        sudoku:
+        - - 12345
+          - 12345
+        - - 12345
+          - 12345

--- a/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/multi_dim_array/openapi.yml
+++ b/src/test/java/dk/jyskebank/tools/enunciate/modules/openapi/multi_dim_array/openapi.yml
@@ -1,0 +1,93 @@
+openapi: 3.0.0
+info:
+  title: "Title from enunciate.xml"
+  version: "version from enunciate.xml"
+  description: "Description from enunciate.xml. Can contain weird letters æøåÆØÅ"
+servers: []
+paths:
+  "/data/{pathArg}":
+    post:
+      description: "Summary.\n\nDescription follows..."
+      tags:
+        - "Data"
+      summary: "Summary."
+      deprecated: false
+      operationId: update
+      parameters:
+      - name: "userid"
+        in: header
+        description: "The actual user performing the operation"
+        required: false
+        schema:
+          type: string
+        style: simple
+      - name: "pathArg"
+        in: path
+        description: "The id of the customer"
+        required: true
+        schema:
+          type: string
+        style: simple
+      requestBody:
+        description: ""
+        required: true
+        content:
+          "application/json":
+            schema:
+              $ref: "#/components/schemas/json_DataDTO"
+      responses:
+        "201":
+          description: "Created, Consents created"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/json_DataDTO"
+        "204":
+          description: "No Content, Current consents updated"
+          content:
+            "application/json":
+              schema:
+                description: "No Content, Current consents updated"
+                type: string
+                format: binary
+        "400":
+          description: "Bad request, inspect response payload for error details"
+        "401":
+          description: "Unauthorized, please provide valid Authentication header"
+        "403":
+          description: "Forbidden, user does not have permission"
+        "404":
+          description: "Not Found, inspect response for more info"
+        "500":
+          description: "Internal Server Error, Unexpected server error"
+ 
+components:
+  schemas:
+    "json_DataDTO":
+      title: "multiDimArraySupport"
+      type: object
+      properties:
+        "name":
+          type: string
+        "temperatures":
+          type: array
+          items:
+            type: array
+            items:
+              type: integer
+              format: int32
+        "locations":
+          type: array
+          items:
+            type: integer
+            format: int32
+      example:
+        name: "..."
+        temperatures:
+        - - 12345
+          - 12345
+        - - 12345
+          - 12345
+        locations:
+        - 12345
+        - 12345


### PR DESCRIPTION
Now that Enunciate supports multi dimensional arrays, like int[][], this changes adds this to the module. Note that you have to use @TypeHint(int[][].class) on the field's getter in order to get the correct type in the HTML of Enunciate. For the Jyske module @TypeHint is not needed.